### PR TITLE
K8sFilesLoader: return error on bad directory permissions

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -49,6 +49,10 @@ func GetFilesByExt(inputPath string, exts []string) ([]string, error) {
 		log.Warnf("The path %q is not a directory.", inputPath)
 	}
 	err := filepath.Walk(inputPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil && path == inputPath { // if walk for root search path return gets error
+			// then stop walking and return this error
+			return err
+		}
 		if err != nil {
 			log.Warnf("Skipping path %q due to error: %q", path, err)
 			return nil
@@ -83,6 +87,10 @@ func GetFilesByName(inputPath string, names []string) ([]string, error) {
 		log.Warnf("The path %q is not a directory.", inputPath)
 	}
 	err := filepath.Walk(inputPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil && path == inputPath { // if walk for root search path return gets error
+			// then stop walking and return this error
+			return err
+		}
 		if err != nil {
 			log.Warnf("Skipping path %q due to error: %q", path, err)
 			return nil
@@ -101,7 +109,7 @@ func GetFilesByName(inputPath string, names []string) ([]string, error) {
 	})
 	if err != nil {
 		log.Warnf("Error in walking through files due to : %s", err)
-		return files, nil
+		return files, err
 	}
 	log.Debugf("No of files with %s names identified : %d", names, len(files))
 	return files, nil

--- a/internal/common/utils_test.go
+++ b/internal/common/utils_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -72,17 +73,16 @@ func TestGetFilesByExt(t *testing.T) {
 		}
 	})
 
-	// TODO: do we need to handle this edge case?
-	// t.Run("get files by extension when you don't have permissions for the directory", func(t *testing.T) {
-	// 	parentDir := t.TempDir()
-	// 	path1 := filepath.Join(parentDir, "app1")
-	// 	if err := os.Mkdir(path1, 0); err != nil {
-	// 		t.Fatal("Failed to create the temporary directory", path1, "for testing. Error:", err)
-	// 	}
-	// 	if _, err := common.GetFilesByExt(path1, []string{".yaml", ".yml"}); err == nil {
-	// 		t.Fatal("Should have given an error since we don't have permissions to read the directory.")
-	// 	}
-	// })
+	t.Run("get files by extension when you don't have permissions for the directory", func(t *testing.T) {
+		parentDir := t.TempDir()
+		path1 := filepath.Join(parentDir, "app1")
+		if err := os.Mkdir(path1, 0); err != nil {
+			t.Fatal("Failed to create the temporary directory", path1, "for testing. Error:", err)
+		}
+		if _, err := common.GetFilesByExt(path1, []string{".yaml", ".yml"}); err == nil {
+			t.Fatal("Should have given an error since we don't have permissions to read the directory.")
+		}
+	})
 }
 
 func TestGetFilesByName(t *testing.T) {
@@ -127,17 +127,16 @@ func TestGetFilesByName(t *testing.T) {
 		}
 	})
 
-	// TODO: do we need to handle this edge case?
-	// t.Run("get files by name when you don't have permissions for the directory", func(t *testing.T) {
-	// 	parentDir := t.TempDir()
-	// 	path1 := filepath.Join(parentDir, "app1")
-	// 	if err := os.Mkdir(path1, 0); err != nil {
-	// 		t.Fatal("Failed to create the temporary directory", path1, "for testing. Error:", err)
-	// 	}
-	// 	if _, err := common.GetFilesByName(path1, []string{"test1.yaml", "test2.yml"}); err == nil {
-	// 		t.Fatal("Should have given an error since we don't have permissions to read the directory.")
-	// 	}
-	// })
+	t.Run("get files by name when you don't have permissions for the directory", func(t *testing.T) {
+		parentDir := t.TempDir()
+		path1 := filepath.Join(parentDir, "app1")
+		if err := os.Mkdir(path1, 0); err != nil {
+			t.Fatal("Failed to create the temporary directory", path1, "for testing. Error:", err)
+		}
+		if _, err := common.GetFilesByName(path1, []string{"test1.yaml", "test2.yml"}); err == nil {
+			t.Fatal("Should have given an error since we don't have permissions to read the directory.")
+		}
+	})
 }
 
 func TestYamlAttrPresent(t *testing.T) {

--- a/internal/metadata/k8sfiles.go
+++ b/internal/metadata/k8sfiles.go
@@ -17,7 +17,9 @@ limitations under the License.
 package metadata
 
 import (
+	"errors"
 	"io/ioutil"
+	"syscall"
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -38,6 +40,9 @@ func (i K8sFilesLoader) UpdatePlan(inputPath string, plan *plantypes.Plan) error
 
 	files, err := common.GetFilesByExt(inputPath, []string{".yml", ".yaml"})
 	if err != nil {
+		if errors.Is(err, syscall.EACCES) { // if err is permission denied error then return it
+			return err
+		}
 		log.Warnf("Unable to fetch yaml files and recognize k8 yamls : %s", err)
 	}
 	for _, path := range files {

--- a/internal/metadata/k8sfiles.go
+++ b/internal/metadata/k8sfiles.go
@@ -56,9 +56,9 @@ func (i K8sFilesLoader) UpdatePlan(inputPath string, plan *plantypes.Plan) error
 		if err != nil {
 			log.Debugf("ignoring file %s since serialization failed", path)
 			continue
-		} else {
-			plan.Spec.Inputs.K8sFiles = append(plan.Spec.Inputs.K8sFiles, relpath)
 		}
+
+		plan.Spec.Inputs.K8sFiles = append(plan.Spec.Inputs.K8sFiles, relpath)
 	}
 	return nil
 }
@@ -77,9 +77,9 @@ func (i K8sFilesLoader) LoadToIR(p plantypes.Plan, ir *irtypes.IR) error {
 		if err != nil {
 			log.Debugf("ignoring file %s since serialization failed", path)
 			continue
-		} else {
-			ir.CachedObjects = append(ir.CachedObjects, obj)
 		}
+
+		ir.CachedObjects = append(ir.CachedObjects, obj)
 	}
 	return nil
 }

--- a/internal/metadata/k8sfiles.go
+++ b/internal/metadata/k8sfiles.go
@@ -17,9 +17,7 @@ limitations under the License.
 package metadata
 
 import (
-	"errors"
 	"io/ioutil"
-	"syscall"
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -40,10 +38,7 @@ func (i K8sFilesLoader) UpdatePlan(inputPath string, plan *plantypes.Plan) error
 
 	files, err := common.GetFilesByExt(inputPath, []string{".yml", ".yaml"})
 	if err != nil {
-		if errors.Is(err, syscall.EACCES) { // if err is permission denied error then return it
-			return err
-		}
-		log.Warnf("Unable to fetch yaml files and recognize k8 yamls : %s", err)
+		return err
 	}
 	for _, path := range files {
 		relpath, _ := plan.GetRelativePath(path)


### PR DESCRIPTION
K8sFilesLoader now handles bad directory permissions error and returns it.

GetFilesByExt, GetFilesByName are fixed and return bad file permissions error when it occurs on root search directory.
This makes possible to uncomment respective tests and remove TODOs: 
https://github.com/konveyor/move2kube/blob/c9b5d0f8497ccf1dc61dd90879da9ad8b427967a/internal/common/utils_test.go#L75-L85
https://github.com/konveyor/move2kube/blob/c9b5d0f8497ccf1dc61dd90879da9ad8b427967a/internal/common/utils_test.go#L130-L140

In addition to that changes K8sFilesLoader to be more idiomatic: removes unnecessary `else` block after `continue` in `for` loop

Removes TODO for bad permission test introduced in https://github.com/konveyor/move2kube/pull/30
Closes #31 