### PR TITLE
Refactor tests

### DIFF
--- a/internal/optimizer/imagepullpolicyoptimizer_test.go
+++ b/internal/optimizer/imagepullpolicyoptimizer_test.go
@@ -47,9 +47,9 @@ func TestImagePullPolicyOptimizer(t *testing.T) {
 
 	t.Run("IR containing services that have no containers", func(t *testing.T) {
 		// Setup
-		ir := getIRWithServiceAndWithoutContainers()
+		ir := getIRWithServicesAndWithoutContainers()
 		imagePullPolicyOptimizer := imagePullPolicyOptimizer{}
-		want := getIRWithServiceAndWithoutContainers()
+		want := getIRWithServicesAndWithoutContainers()
 
 		// Test
 		actual, err := imagePullPolicyOptimizer.optimize(ir)
@@ -111,7 +111,7 @@ func TestImagePullPolicyOptimizer(t *testing.T) {
 	})
 }
 
-func getIRWithServiceAndWithoutContainers() types.IR {
+func getIRWithServicesAndWithoutContainers() types.IR {
 	svcname1 := "svcname1"
 	svcname2 := "svcname2"
 	svc1 := types.Service{Name: svcname1, Replicas: 2}

--- a/internal/optimizer/portmergeoptimizer_test.go
+++ b/internal/optimizer/portmergeoptimizer_test.go
@@ -46,9 +46,9 @@ func TestPortMergeOptimizer(t *testing.T) {
 
 	t.Run("IR containing services that have no containers", func(t *testing.T) {
 		// Setup
-		ir := getIRWithServiceAndWithoutContainers()
+		ir := getIRWithServicesAndWithoutContainers()
 		portMergeOptimizer := portMergeOptimizer{}
-		want := getIRWithServiceAndWithoutContainers()
+		want := getIRWithServicesAndWithoutContainers()
 
 		// Test
 		actual, err := portMergeOptimizer.optimize(ir)


### PR DESCRIPTION
- Remove assigning input to the expected output with `:=` in tests

- Replace duplicate code / Reuse functions

- Rename function