### PR TITLE
move CI routine to a make target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ cache:
   directories:
   - "$GOPATH/pkg/mod"
 script:
-- make test
-- make build
-- make test-style
+- make ci
 after_success:
 - echo "$QUAY_BOT_PASSWORD" | docker login --username "$QUAY_BOT_USERNAME" --password-stdin
   quay.io

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,11 @@ test-style: ${GOLANGCILINT} ${GOLINT}
 	${GOLINT} ${PKG}
 	scripts/licensecheck.sh
 
+# -- CI --
+
+.PHONY: ci
+ci: test build test-style ## Run CI routine
+
 # -- Release --
 
 $(GOX):


### PR DESCRIPTION
make test, build, test-style are all called when running `make ci`