### PR TITLE
fix bug where errors that occurred while detecting a yaml file as a cfmanifest was displayed to the user.

### DIFF
--- a/internal/source/cfmanifest2kube.go
+++ b/internal/source/cfmanifest2kube.go
@@ -379,13 +379,13 @@ func ReadApplicationManifest(path string, serviceName string, artifactType plant
 	trimmedvariables, err := getMissingVariables(path)
 	if err != nil {
 		log.Debugf("Unable to read as cf manifest %s : %s", path, err)
-		return []manifest.Application{}, []string{}, err
+		return nil, nil, err
 	}
 
 	rawManifest, err := ioutil.ReadFile(path)
 	if err != nil {
-		log.Errorf("Unable to read manifest file %s", path)
-		return []manifest.Application{}, []string{}, err
+		log.Errorf("Unable to read manifest file at path %q Error: %q", path, err)
+		return nil, nil, err
 	}
 	tpl := template.NewTemplate(rawManifest)
 	fileVars := template.StaticVariables{}
@@ -398,15 +398,15 @@ func ReadApplicationManifest(path string, serviceName string, artifactType plant
 	}
 	rawManifest, err = tpl.Evaluate(fileVars, nil, template.EvaluateOpts{ExpectAllKeys: true})
 	if err != nil {
-		log.Errorf("Interpolation Error %s", err)
-		return []manifest.Application{}, []string{}, err
+		log.Debugf("Interpolation Error %s", err)
+		return nil, nil, err
 	}
 
 	var m manifest.Manifest
 	err = yaml.Unmarshal(rawManifest, &m)
 	if err != nil {
-		log.Errorf("UnMarshalling error %s", err)
-		return []manifest.Application{}, []string{}, err
+		log.Debugf("UnMarshalling error %s", err)
+		return nil, nil, err
 	}
 	if len(m.Applications) == 1 {
 		//If the service name is missing, use the directory name


### PR DESCRIPTION
# Bug
We try to parse every yaml file we find as a cfmanifest file. Naturally there will be a lot of errors during parsing since
most(if not all) yamls will not be cfmanifests.

These errors were being displayed to the user:
```
$ move2kube plan -s ref-impl
INFO[0000] Planning Translation                         
INFO[0000] [*source.DockerfileTranslator] Planning translation 
INFO[0001] [*source.DockerfileTranslator] Done          
INFO[0001] [*source.ComposeTranslator] Planning translation 
INFO[0001] [*source.ComposeTranslator] Done             
INFO[0001] [*source.CfManifestTranslator] Planning translation 
ERRO[0001] Interpolation Error Expected to find exactly one matching array item for path '/variables/name=' but found 0 
INFO[0001] [*source.CfManifestTranslator] Done          
INFO[0001] [*source.KnativeTranslator] Planning translation 
INFO[0001] [*source.KnativeTranslator] Done             
INFO[0001] [*source.KubeTranslator] Planning translation 
INFO[0001] [*source.KubeTranslator] Done                
INFO[0001] [*source.Any2KubeTranslator] Planning translation 
INFO[0004] [*source.Any2KubeTranslator] Done            
INFO[0004] Translation planning done                    
INFO[0004] Planning Metadata                            
INFO[0004] [*metadata.ClusterMDLoader] Planning metadata 
INFO[0004] [*metadata.ClusterMDLoader] Done             
INFO[0004] [*metadata.K8sFilesLoader] Planning metadata 
INFO[0004] [*metadata.K8sFilesLoader] Done              
INFO[0004] [*metadata.QACacheLoader] Planning metadata  
INFO[0004] [*metadata.QACacheLoader] Done               
INFO[0004] Metadata planning done                       
INFO[0004] Plan can be found at [/foo/bar/m2k.plan]. 
```

# Fix
Changed errors to `log.Debugf`

Signed-off-by: Harikrishnan Balagopal <Harikrishnan.Balagopal@ibm.com>