### PR TITLE
fix bug where collect was not using the API

### DIFF
--- a/cmd/move2kube/collect.go
+++ b/cmd/move2kube/collect.go
@@ -21,52 +21,71 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/konveyor/move2kube/internal/move2kube"
+	"github.com/konveyor/move2kube/types"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-
-	"github.com/konveyor/move2kube/internal/move2kube"
-	"github.com/konveyor/move2kube/types"
 )
 
-var (
+type collectFlags struct {
 	annotations string
-)
+	outpath     string
+	srcpath     string
+}
 
 const (
 	annotationsFlag = "annotations"
 )
 
-var collectCmd = &cobra.Command{
-	Use:   "collect",
-	Short: "Collect and process metadata from multiple sources.",
-	Long:  "Collect metadata from multiple sources (cluster, image repo etc.), filter and summarize it into a yaml.",
-	Run: func(cmd *cobra.Command, args []string) {
-		if srcpath != "" {
-			fi, err := os.Stat(srcpath)
-			if os.IsNotExist(err) {
-				log.Fatalf("Source directory does not exist: %s.", err)
-			} else if err != nil {
-				log.Fatalf("Error while accessing directory: %s. ", srcpath)
-			} else if !fi.IsDir() {
-				log.Fatalf("Source path is a file, expected directory: %s.", srcpath)
-			}
+func collectHandler(flags collectFlags) {
+	var err error
+	annotations := flags.annotations
+	outpath := flags.outpath
+	srcpath := flags.srcpath
+
+	if outpath != "" {
+		if outpath, err = filepath.Abs(outpath); err != nil {
+			log.Fatalf("Failed to make the output directory path %q absolute. Error: %q", outpath, err)
 		}
-		outpath = filepath.Join(filepath.Clean(outpath), types.AppNameShort+"_collect")
-		if annotations == "" {
-			move2kube.Collect(srcpath, outpath, []string{})
-		} else {
-			move2kube.Collect(srcpath, outpath, strings.Split(annotations, ","))
+	}
+	if srcpath != "" {
+		srcpath, err = filepath.Abs(srcpath)
+		if err != nil {
+			log.Fatalf("Failed to make the source directory path %q absolute. Error: %q", srcpath, err)
 		}
-		log.Infof("Collect Output in [%s]. Copy this directory into the source directory to be used for planning.", outpath)
-	},
+		fi, err := os.Stat(srcpath)
+		if os.IsNotExist(err) {
+			log.Fatalf("Source directory does not exist: %s.", err)
+		} else if err != nil {
+			log.Fatalf("Error while accessing directory: %s. ", srcpath)
+		} else if !fi.IsDir() {
+			log.Fatalf("Source path is a file, expected directory: %s.", srcpath)
+		}
+	}
+	outpath = filepath.Join(filepath.Clean(outpath), types.AppNameShort+"_collect")
+	if annotations == "" {
+		move2kube.Collect(srcpath, outpath, []string{})
+	} else {
+		move2kube.Collect(srcpath, outpath, strings.Split(annotations, ","))
+	}
+	log.Infof("Collect Output in [%s]. Copy this directory into the source directory to be used for planning.", outpath)
 }
 
 func init() {
 	viper.AutomaticEnv()
 
-	collectCmd.Flags().StringVarP(&annotations, annotationsFlag, "a", "", "Specify annotations to select collector subset.")
-	collectCmd.Flags().StringVarP(&outpath, outpathFlag, "o", ".", "Specify output directory for collect.")
-	collectCmd.Flags().StringVarP(&srcpath, sourceFlag, "s", "", "Specify source directory for the artifacts to be considered while collecting.")
+	flags := collectFlags{}
+	collectCmd := &cobra.Command{
+		Use:   "collect",
+		Short: "Collect and process metadata from multiple sources.",
+		Long:  "Collect metadata from multiple sources (cluster, image repo etc.), filter and summarize it into a yaml.",
+		Run:   func(*cobra.Command, []string) { collectHandler(flags) },
+	}
+
+	collectCmd.Flags().StringVarP(&flags.annotations, annotationsFlag, "a", "", "Specify annotations to select collector subset.")
+	collectCmd.Flags().StringVarP(&flags.outpath, outpathFlag, "o", ".", "Specify output directory for collect.")
+	collectCmd.Flags().StringVarP(&flags.srcpath, sourceFlag, "s", "", "Specify source directory for the artifacts to be considered while collecting.")
+
 	rootCmd.AddCommand(collectCmd)
 }

--- a/cmd/move2kube/move2kube.go
+++ b/cmd/move2kube/move2kube.go
@@ -24,16 +24,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	verbose bool
-
-	planfile  string
-	outpath   string
-	srcpath   string
-	name      string
-	ignoreEnv bool
-)
-
 const (
 	nameFlag      = "name"
 	planFlag      = "plan"
@@ -41,21 +31,19 @@ const (
 	ignoreEnvFlag = "ignoreenv"
 )
 
+var verbose bool
+
 // RootCmd root level flags and commands
 var rootCmd = &cobra.Command{
 	Use:   "move2kube",
 	Short: "A tool to modernize to kubernetes/openshift",
 	Long:  `move2kube is a tool to help optimally translate from platforms such as docker-swarm, CF to Kubernetes.`,
-}
-
-func getRootCmd() *cobra.Command {
-	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+	PersistentPreRunE: func(*cobra.Command, []string) error {
 		if verbose {
 			log.SetLevel(log.DebugLevel)
 		}
 		return nil
-	}
-	return rootCmd
+	},
 }
 
 func init() {
@@ -70,7 +58,7 @@ func main() {
 	common.TempPath = tempPath
 	common.AssetsPath = assetsPath
 	defer os.RemoveAll(tempPath)
-	if err := getRootCmd().Execute(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		log.Fatalf("Error: %q", err)
 	}
 }

--- a/cmd/move2kube/translate.go
+++ b/cmd/move2kube/translate.go
@@ -20,15 +20,27 @@ import (
 	"os"
 	"path/filepath"
 
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
 	"github.com/konveyor/move2kube/internal/common"
 	"github.com/konveyor/move2kube/internal/move2kube"
 	"github.com/konveyor/move2kube/internal/qaengine"
 	"github.com/konveyor/move2kube/types/plan"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+type translateFlags struct {
+	ignoreEnv    bool
+	planfile     string
+	outpath      string
+	srcpath      string
+	name         string
+	curate       bool
+	qadisablecli bool
+	qaskip       bool
+	qaport       int
+	qacaches     []string
+}
 
 const (
 	outpathFlag      = "outpath"
@@ -39,113 +51,112 @@ const (
 	qacacheFlag      = "qacache"
 )
 
-var (
-	curate       bool
-	qadisablecli bool
-	qaskip       bool
-	qaport       int
-	qacaches     []string
-)
+func translateHandler(cmd *cobra.Command, flags translateFlags) {
+	// Setup
+	var err error
+	ignoreEnv := flags.ignoreEnv
+	planfile := flags.planfile
+	srcpath := flags.srcpath
+	outpath := flags.outpath
+	name := flags.name
 
-var translateCmd = &cobra.Command{
-	Use:   "translate",
-	Short: "Translate using move2kube plan",
-	Long:  "Translate artifacts using move2kube plan",
-	Run: func(cmd *cobra.Command, args []string) {
-		// Setup
-		var err error
-		planfile, err = filepath.Abs(planfile)
-		if err != nil {
-			log.Fatalf("Failed to make the plan file path %q absolute. Error: %q", planfile, err)
-		}
-		if srcpath != "" {
-			if srcpath, err = filepath.Abs(srcpath); err != nil {
-				log.Fatalf("Failed to make the source directory path %q absolute. Error: %q", srcpath, err)
-			}
-		}
-		if outpath != "" {
-			if outpath, err = filepath.Abs(outpath); err != nil {
-				log.Fatalf("Failed to make the output directory path %q absolute. Error: %q", outpath, err)
-			}
-		}
-		// Global settings
-		common.IgnoreEnvironment = ignoreEnv
-		qaengine.StartEngine(qaskip, qaport, qadisablecli)
-		cachepaths := []string{}
-		for i := len(qacaches) - 1; i >= 0; i-- {
-			cachepaths = append(cachepaths, qacaches[i])
-		}
-		qaengine.AddCaches(cachepaths)
+	curate := flags.curate
+	qadisablecli := flags.qadisablecli
+	qaskip := flags.qaskip
+	qaport := flags.qaport
+	qacaches := flags.qacaches
 
-		// Parameter cleaning and curate plan
-		var p plan.Plan
-		fi, err := os.Stat(planfile)
-		if err == nil && fi.IsDir() {
-			planfile = filepath.Join(planfile, common.DefaultPlanFile)
-			_, err = os.Stat(planfile)
+	planfile, err = filepath.Abs(planfile)
+	if err != nil {
+		log.Fatalf("Failed to make the plan file path %q absolute. Error: %q", planfile, err)
+	}
+	if srcpath != "" {
+		if srcpath, err = filepath.Abs(srcpath); err != nil {
+			log.Fatalf("Failed to make the source directory path %q absolute. Error: %q", srcpath, err)
 		}
-		if err != nil {
-			if !cmd.Flags().Changed(planFlag) && cmd.Flags().Changed(sourceFlag) {
-				p = move2kube.CreatePlan(srcpath, name)
-				err := qaengine.SetWriteCache(filepath.Join(outpath, p.Name, common.QACacheFile))
-				if err != nil {
-					log.Warnf("Unable to write cache : %s", err)
-				}
-				p = move2kube.CuratePlan(p)
-			} else {
-				log.Fatalf("Error while accessing plan file path %s : %s ", planfile, err)
-			}
-		} else {
-			log.Infof("Detected a plan file in %s. Will translate using this plan.", planfile)
-			p, err = move2kube.ReadPlan(planfile)
+	}
+	if outpath != "" {
+		if outpath, err = filepath.Abs(outpath); err != nil {
+			log.Fatalf("Failed to make the output directory path %q absolute. Error: %q", outpath, err)
+		}
+	}
+	// Global settings
+	common.IgnoreEnvironment = ignoreEnv
+	qaengine.StartEngine(qaskip, qaport, qadisablecli)
+	cachepaths := []string{}
+	for i := len(qacaches) - 1; i >= 0; i-- {
+		cachepaths = append(cachepaths, qacaches[i])
+	}
+	qaengine.AddCaches(cachepaths)
+
+	// Parameter cleaning and curate plan
+	var p plan.Plan
+	fi, err := os.Stat(planfile)
+	if err == nil && fi.IsDir() {
+		planfile = filepath.Join(planfile, common.DefaultPlanFile)
+		_, err = os.Stat(planfile)
+	}
+	if err != nil {
+		if !cmd.Flags().Changed(planFlag) && cmd.Flags().Changed(sourceFlag) {
+			p = move2kube.CreatePlan(srcpath, name)
+			err := qaengine.SetWriteCache(filepath.Join(outpath, p.Name, common.QACacheFile))
 			if err != nil {
-				log.Fatalf("Unable to read plan : %s", err)
+				log.Warnf("Unable to write cache : %s", err)
 			}
-			if cmd.Flags().Changed(nameFlag) {
-				p.Name = name
-			}
-			if curate {
-				err = qaengine.SetWriteCache(filepath.Join(outpath, p.Name, common.QACacheFile))
-				if err != nil {
-					log.Warnf("Unable to write cache : %s", err)
-				}
-				p = move2kube.CuratePlan(p)
-			}
-		}
-		if srcpath != "" {
-			if err := move2kube.SetRootDir(&p, srcpath); err != nil {
-				log.Fatalf("Failed to set the root directory to %q Error: %q", srcpath, err)
-			}
-		}
-		fi, err = os.Stat(p.Spec.Inputs.RootDir)
-		if os.IsNotExist(err) {
-			log.Fatalf("Source directory does not exist: %s.", err)
-		} else if err != nil {
-			log.Fatalf("Error while accessing source directory: %s. ", p.Spec.Inputs.RootDir)
-		} else if !fi.IsDir() {
-			log.Fatalf("Source path is a file, expected directory: %s.", p.Spec.Inputs.RootDir)
-		}
-
-		outpath = filepath.Join(outpath, p.Name)
-		fi, err = os.Stat(outpath)
-		if os.IsNotExist(err) {
-			log.Debugf("Translated artifacts will be written to %s.", outpath)
-		} else if err != nil {
-			log.Fatalf("Error while accessing output directory: %s (%s). Exiting", outpath, err)
-		} else if !fi.IsDir() {
-			log.Fatalf("Output path is a file, expected directory: %s. Exiting", outpath)
+			p = move2kube.CuratePlan(p)
 		} else {
-			log.Infof("Output directory exists: %s. The contents might get overwritten.", outpath)
+			log.Fatalf("Error while accessing plan file path %s : %s ", planfile, err)
 		}
-		err = qaengine.SetWriteCache(filepath.Join(outpath, common.QACacheFile))
+	} else {
+		log.Infof("Detected a plan file in %s. Will translate using this plan.", planfile)
+		p, err = move2kube.ReadPlan(planfile)
 		if err != nil {
-			log.Warnf("Unable to write cache : %s", err)
+			log.Fatalf("Unable to read plan : %s", err)
 		}
+		if cmd.Flags().Changed(nameFlag) {
+			p.Name = name
+		}
+		if curate {
+			err = qaengine.SetWriteCache(filepath.Join(outpath, p.Name, common.QACacheFile))
+			if err != nil {
+				log.Warnf("Unable to write cache : %s", err)
+			}
+			p = move2kube.CuratePlan(p)
+		}
+	}
+	if srcpath != "" {
+		if err := move2kube.SetRootDir(&p, srcpath); err != nil {
+			log.Fatalf("Failed to set the root directory to %q Error: %q", srcpath, err)
+		}
+	}
+	fi, err = os.Stat(p.Spec.Inputs.RootDir)
+	if os.IsNotExist(err) {
+		log.Fatalf("Source directory does not exist: %s.", err)
+	} else if err != nil {
+		log.Fatalf("Error while accessing source directory: %s. ", p.Spec.Inputs.RootDir)
+	} else if !fi.IsDir() {
+		log.Fatalf("Source path is a file, expected directory: %s.", p.Spec.Inputs.RootDir)
+	}
 
-		// Translate
-		move2kube.Translate(p, outpath)
-		log.Infof("Translated target artifacts can be found at [%s].", outpath)
-	},
+	outpath = filepath.Join(outpath, p.Name)
+	fi, err = os.Stat(outpath)
+	if os.IsNotExist(err) {
+		log.Debugf("Translated artifacts will be written to %s.", outpath)
+	} else if err != nil {
+		log.Fatalf("Error while accessing output directory: %s (%s). Exiting", outpath, err)
+	} else if !fi.IsDir() {
+		log.Fatalf("Output path is a file, expected directory: %s. Exiting", outpath)
+	} else {
+		log.Infof("Output directory exists: %s. The contents might get overwritten.", outpath)
+	}
+	err = qaengine.SetWriteCache(filepath.Join(outpath, common.QACacheFile))
+	if err != nil {
+		log.Warnf("Unable to write cache : %s", err)
+	}
+
+	// Translate
+	move2kube.Translate(p, outpath)
+	log.Infof("Translated target artifacts can be found at [%s].", outpath)
 }
 
 func init() {
@@ -156,21 +167,29 @@ func init() {
 	}
 	viper.AutomaticEnv()
 
+	flags := translateFlags{}
+	translateCmd := &cobra.Command{
+		Use:   "translate",
+		Short: "Translate using move2kube plan",
+		Long:  "Translate artifacts using move2kube plan",
+		Run:   func(cmd *cobra.Command, _ []string) { translateHandler(cmd, flags) },
+	}
+
 	// Basic options
-	translateCmd.Flags().StringVarP(&planfile, planFlag, "p", common.DefaultPlanFile, "Specify a plan file to execute.")
-	translateCmd.Flags().BoolVarP(&curate, curateFlag, "c", false, "Specify whether to curate the plan with a q/a.")
-	translateCmd.Flags().StringVarP(&srcpath, sourceFlag, "s", "", "Specify source directory to translate. If you already have a m2k.plan then this will override the rootdir value specified in that plan.")
-	translateCmd.Flags().StringVarP(&outpath, outpathFlag, "o", "", "Path for output. Default will be directory with the project name.")
-	translateCmd.Flags().StringVarP(&name, nameFlag, "n", common.DefaultProjectName, "Specify the project name.")
-	translateCmd.Flags().StringSliceVarP(&qacaches, qacacheFlag, "q", []string{}, "Specify qa cache file locations")
+	translateCmd.Flags().StringVarP(&flags.planfile, planFlag, "p", common.DefaultPlanFile, "Specify a plan file to execute.")
+	translateCmd.Flags().BoolVarP(&flags.curate, curateFlag, "c", false, "Specify whether to curate the plan with a q/a.")
+	translateCmd.Flags().StringVarP(&flags.srcpath, sourceFlag, "s", "", "Specify source directory to translate. If you already have a m2k.plan then this will override the rootdir value specified in that plan.")
+	translateCmd.Flags().StringVarP(&flags.outpath, outpathFlag, "o", "", "Path for output. Default will be directory with the project name.")
+	translateCmd.Flags().StringVarP(&flags.name, nameFlag, "n", common.DefaultProjectName, "Specify the project name.")
+	translateCmd.Flags().StringSliceVarP(&flags.qacaches, qacacheFlag, "q", []string{}, "Specify qa cache file locations")
 
 	// Advanced options
-	translateCmd.Flags().BoolVar(&ignoreEnv, ignoreEnvFlag, false, "Ignore data from local machine.")
+	translateCmd.Flags().BoolVar(&flags.ignoreEnv, ignoreEnvFlag, false, "Ignore data from local machine.")
 
 	// Hidden options
-	translateCmd.Flags().BoolVar(&qadisablecli, qadisablecliFlag, false, "Enable/disable the QA Cli sub-system. Without this system, you will have to use the REST API to interact.")
-	translateCmd.Flags().BoolVar(&qaskip, qaskipFlag, false, "Enable/disable the default answers to questions posed in QA Cli sub-system. If disabled, you will have to answer the questions posed by QA during interaction.")
-	translateCmd.Flags().IntVar(&qaport, qaportFlag, 0, "Port for the QA service. By default it chooses a random free port.")
+	translateCmd.Flags().BoolVar(&flags.qadisablecli, qadisablecliFlag, false, "Enable/disable the QA Cli sub-system. Without this system, you will have to use the REST API to interact.")
+	translateCmd.Flags().BoolVar(&flags.qaskip, qaskipFlag, false, "Enable/disable the default answers to questions posed in QA Cli sub-system. If disabled, you will have to answer the questions posed by QA during interaction.")
+	translateCmd.Flags().IntVar(&flags.qaport, qaportFlag, 0, "Port for the QA service. By default it chooses a random free port.")
 
 	must(translateCmd.Flags().MarkHidden(qadisablecliFlag))
 	must(translateCmd.Flags().MarkHidden(qaskipFlag))

--- a/cmd/move2kube/version.go
+++ b/cmd/move2kube/version.go
@@ -24,19 +24,16 @@ import (
 	"github.com/spf13/viper"
 )
 
-var long bool
-
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print the client version information",
-	Long:  "Print the client version information",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(move2kube.GetVersion(long))
-	},
-}
-
 func init() {
 	viper.AutomaticEnv()
+
+	long := false
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the client version information",
+		Long:  "Print the client version information",
+		Run:   func(*cobra.Command, []string) { fmt.Println(move2kube.GetVersion(long)) },
+	}
 
 	versionCmd.Flags().BoolVarP(&long, "long", "l", false, "print the version details")
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -24,6 +24,6 @@ type Collector interface {
 
 // GetCollectors returns different collectors
 func GetCollectors() ([]Collector, error) {
-	var collectors = []Collector{new(ClusterCollector), new(ImagesCollector), new(CFContainerTypesCollector), new(CfAppsCollector)}
+	collectors := []Collector{new(ClusterCollector), new(ImagesCollector), new(CFContainerTypesCollector), new(CfAppsCollector)}
 	return collectors, nil
 }

--- a/types/collection/cluster.go
+++ b/types/collection/cluster.go
@@ -115,7 +115,7 @@ func (c *ClusterMetadataSpec) GetSupportedVersions(kind string) []string {
 
 // NewClusterMetadata creates a new cluster metadata instance
 func NewClusterMetadata(contextName string) ClusterMetadata {
-	var clusterMetadata = ClusterMetadata{
+	return ClusterMetadata{
 		TypeMeta: types.TypeMeta{
 			Kind:       string(ClusterMetadataKind),
 			APIVersion: types.SchemeGroupVersion.String(),
@@ -126,8 +126,6 @@ func NewClusterMetadata(contextName string) ClusterMetadata {
 		Spec: ClusterMetadataSpec{
 			StorageClasses:    []string{},
 			APIKindVersionMap: map[string][]string{},
-			Host:              "",
 		},
 	}
-	return clusterMetadata
 }


### PR DESCRIPTION
# Bug
`client-go` isn't properly importing openid connect.
This causes the call to get an API client to always fail.

# Fix
Added a blank import as suggested in the github issue:
https://github.com/kubernetes/client-go/issues/345

Also refactored CLI by removing globals.

Signed-off-by: Harikrishnan Balagopal <Harikrishnan.Balagopal@ibm.com>