### PR TITLE
fixed bug with SetRootDir and added tests

### DIFF
--- a/internal/move2kube/testdata/setrootdir/nodejsplan.yaml
+++ b/internal/move2kube/testdata/setrootdir/nodejsplan.yaml
@@ -1,0 +1,66 @@
+apiVersion: move2kube.konveyor.io/v1alpha1
+kind: Plan
+metadata:
+  name: nodejs-app
+spec:
+  inputs:
+    rootDir: ../../samples/nodejs
+    services:
+      nodejs:
+        - serviceName: nodejs
+          serviceRelPath: /nodejs
+          image: nodejs:latest
+          translationType: Any2Kube
+          containerBuildType: NewDockerfile
+          sourceType:
+            - Directory
+          targetOptions:
+            - m2kassets/dockerfiles/nodejs
+          sourceArtifacts:
+            SourceCode:
+              - .
+          buildArtifacts:
+            SourceCode:
+              - .
+          updateContainerBuildPipeline: true
+          updateDeployPipeline: true
+        - serviceName: nodejs
+          serviceRelPath: /nodejs
+          image: nodejs:latest
+          translationType: Any2Kube
+          containerBuildType: S2I
+          sourceType:
+            - Directory
+          targetOptions:
+            - m2kassets/s2i/nodejs
+          sourceArtifacts:
+            SourceCode:
+              - .
+          buildArtifacts:
+            SourceCode:
+              - .
+          updateContainerBuildPipeline: true
+          updateDeployPipeline: true
+        - serviceName: nodejs
+          serviceRelPath: /nodejs
+          image: nodejs:latest
+          translationType: Any2Kube
+          containerBuildType: CNB
+          sourceType:
+            - Directory
+          targetOptions:
+            - cloudfoundry/cnb:cflinuxfs3
+            - gcr.io/buildpacks/builder
+          sourceArtifacts:
+            SourceCode:
+              - .
+          buildArtifacts:
+            SourceCode:
+              - .
+          updateContainerBuildPipeline: true
+          updateDeployPipeline: true
+  outputs:
+    kubernetes:
+      artifactType: Yamls
+      targetCluster:
+        type: Kubernetes

--- a/internal/move2kube/testdata/writeplan/nodejsplan.yaml
+++ b/internal/move2kube/testdata/writeplan/nodejsplan.yaml
@@ -1,0 +1,66 @@
+apiVersion: move2kube.konveyor.io/v1alpha1
+kind: Plan
+metadata:
+  name: nodejs-app
+spec:
+  inputs:
+    rootDir: ../../samples/nodejs
+    services:
+      nodejs:
+        - serviceName: nodejs
+          serviceRelPath: /nodejs
+          image: nodejs:latest
+          translationType: Any2Kube
+          containerBuildType: NewDockerfile
+          sourceType:
+            - Directory
+          targetOptions:
+            - m2kassets/dockerfiles/nodejs
+          sourceArtifacts:
+            SourceCode:
+              - .
+          buildArtifacts:
+            SourceCode:
+              - .
+          updateContainerBuildPipeline: true
+          updateDeployPipeline: true
+        - serviceName: nodejs
+          serviceRelPath: /nodejs
+          image: nodejs:latest
+          translationType: Any2Kube
+          containerBuildType: S2I
+          sourceType:
+            - Directory
+          targetOptions:
+            - m2kassets/s2i/nodejs
+          sourceArtifacts:
+            SourceCode:
+              - .
+          buildArtifacts:
+            SourceCode:
+              - .
+          updateContainerBuildPipeline: true
+          updateDeployPipeline: true
+        - serviceName: nodejs
+          serviceRelPath: /nodejs
+          image: nodejs:latest
+          translationType: Any2Kube
+          containerBuildType: CNB
+          sourceType:
+            - Directory
+          targetOptions:
+            - cloudfoundry/cnb:cflinuxfs3
+            - gcr.io/buildpacks/builder
+          sourceArtifacts:
+            SourceCode:
+              - .
+          buildArtifacts:
+            SourceCode:
+              - .
+          updateContainerBuildPipeline: true
+          updateDeployPipeline: true
+  outputs:
+    kubernetes:
+      artifactType: Yamls
+      targetCluster:
+        type: Kubernetes


### PR DESCRIPTION
SetRootDir was not updating the paths because
it was checking if the path was absolute and if so
returning the same path unchanged.

Fix: rewrote the logic for SetRootDir

Also added some tests for SetRootDir, ReadPlan and WritePlan

Signed-off-by: Harikrishnan Balagopal <Harikrishnan.Balagopal@ibm.com>