### PR TITLE
Rename docker-compose tutorial

### DIFF
--- a/docs/tutorials/docker-compose.md
+++ b/docs/tutorials/docker-compose.md
@@ -1,12 +1,12 @@
 ---
 layout: default
-title: "Migrating Docker apps to Kubernetes"
+title: "Migrating Docker compose/swarm apps to Kubernetes"
 permalink: /tutorials/docker-compose/
 parent: Tutorials
 nav_order: 2
 ---
 
-# Migrating and deploying Docker applications to Kubernetes
+# Migrating and deploying Docker compose/swarm applications to Kubernetes
 
 ## Description
 


### PR DESCRIPTION
Signed-off-by: Akash Nayak <akash19nayak@gmail.com>
Rename "Migrating Docker apps to Kubernetes" to "Migrating Docker compose/swarm apps to Kubernetes" - https://github.com/konveyor/move2kube/issues/249