### PR TITLE
fixes bug where some apps where going into CrashLoopBackoff when used with DeploymentConfig on Openshift

### DIFF
--- a/internal/apiresource/imagestream.go
+++ b/internal/apiresource/imagestream.go
@@ -17,8 +17,6 @@ limitations under the License.
 package apiresource
 
 import (
-	"strings"
-
 	okdimagev1 "github.com/openshift/api/image/v1"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -81,18 +79,16 @@ func (d *ImageStream) createImageStream(name string, service irtypes.Service) []
 		}
 
 		var tags []okdimagev1.TagReference
-		imagename, tag := common.GetImageNameAndTag(serviceContainer.Image)
+		_, tag := common.GetImageNameAndTag(serviceContainer.Image)
 		tags = []okdimagev1.TagReference{
 			{
 				From: &corev1.ObjectReference{
 					Kind: "DockerImage",
-					Name: imagename,
+					Name: serviceContainer.Image,
 				},
 				Name: tag,
 			},
 		}
-
-		dockerImageRepo := strings.Split(serviceContainer.Image, ":")[0]
 
 		is := &okdimagev1.ImageStream{
 			TypeMeta: metav1.TypeMeta{
@@ -103,10 +99,7 @@ func (d *ImageStream) createImageStream(name string, service irtypes.Service) []
 				Name:   name,
 				Labels: getServiceLabels(name),
 			},
-			Spec: okdimagev1.ImageStreamSpec{
-				DockerImageRepository: dockerImageRepo,
-				Tags:                  tags,
-			},
+			Spec: okdimagev1.ImageStreamSpec{Tags: tags},
 		}
 		imageStreams = append(imageStreams, is)
 	}


### PR DESCRIPTION
The bug is in ImageStream. The dockerImageRepository field
was deprecated in favor of .spec.tags.[].from.name
We are using both fields. Openshift ignores the deprecated
field and only uses the new field .spec.tags.[].from.name
To make matters worse, we only specify the short image name in
the new field. Example:
```
dockerImageRepository: docker.io/username/golang
tags:
  - name: latest
    from:
      kind: DockerImage
      name: golang
```
results in it pulling docker.io/library/golang:latest

Fix: Avoid using the deprecated field and provide the
fully qualifed image name and tag in the new field.

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>