### PR TITLE
Resolve Back to top link issue on mobile website

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,2 +1,2 @@
 <link rel="stylesheet" type="text/css" href="/move2kube/assets/css/asciinema-player.css" />
-<script src="/move2kube/assets/js/asciinema-player.js"></script>
+<script type="javascript" src="/move2kube/assets/js/asciinema-player.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -146,7 +146,7 @@ layout: table_wrappers
           <hr>
           <footer>
             {% if site.back_to_top %}
-              <p><a href="#top" id="back-to-top">{{ site.back_to_top_text }}</a></p>
+              <p><a href="#top" id="back-to-top">{{ site.back_to_top_text }}</a></p><br class="hidden-br"><br class="hidden-br"><br class="hidden-br"><br class="hidden-br"><br class="hidden-br">
             {% endif %}
             {% if site.footer_content != nil %}
               <p class="text-small text-grey-dk-000 mb-0">{{ site.footer_content }}</p>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -16,3 +16,10 @@
 .icon-link {
 text-decoration: none;
 }
+
+/* to give line break if screen width is less than 800px */
+@media (min-width: 800px) {
+  .hidden-br {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
https://github.com/konveyor/move2kube/issues/225

<img width="445" alt="Screenshot 2020-11-30 at 4 01 24 PM" src="https://user-images.githubusercontent.com/14867323/100598864-4f2ba900-3325-11eb-8816-c8219e3f555d.png">

The `Back to top` link was overlapping with the Konveyor logo on the the mobile version of the website.

<img width="441" alt="Screenshot 2020-11-30 at 4 02 07 PM" src="https://user-images.githubusercontent.com/14867323/100598952-68345a00-3325-11eb-8564-2e7bba412cff.png">
