### PR TITLE
feat: ask which translation types the user is interested in

### DIFF
--- a/.grenrc.js
+++ b/.grenrc.js
@@ -1,6 +1,6 @@
 let printPreamble = true;
-const preamble = `# Changelog
-For more documentation and support please visit the website https://konveyor.github.io/move2kube/
+const preamble = `For more documentation and support please visit https://konveyor.io/move2kube/
+# Changelog
 `;
 
 function printPreambleAndGroupName({ heading }) {

--- a/internal/qaengine/engine.go
+++ b/internal/qaengine/engine.go
@@ -85,7 +85,7 @@ func FetchAnswer(prob qatypes.Problem) (ans qatypes.Problem, err error) {
 	for _, e := range engines {
 		ans, err = e.FetchAnswer(prob)
 		if err != nil {
-			log.Warnf("Error while fetching answer using engine %s : %s", e, err)
+			log.Debugf("Error while fetching answer using engine %+v Error: %q", e, err)
 		} else if ans.Resolved {
 			break
 		}


### PR DESCRIPTION
This is useful if we are translating a docker compose
project for example. We know for sure that we only
want services detected by Compose2Kube.

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>