### PR TITLE
fix: If cf app path directory is missing, assume manifest path as app source location

### DIFF
--- a/internal/source/cfmanifest2kube.go
+++ b/internal/source/cfmanifest2kube.go
@@ -19,6 +19,7 @@ package source
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -103,7 +104,12 @@ func (cfManifestTranslator *CfManifestTranslator) GetServiceOptions(inputPath st
 		for _, application := range applications {
 			fullbuilddirectory := filepath.Dir(filePath)
 			if application.Path != "" {
-				fullbuilddirectory = filepath.Join(filepath.Dir(filePath), application.Path)
+				fullappdirectory := filepath.Join(filepath.Dir(filePath), application.Path)
+				if _, err := os.Stat(fullappdirectory); !os.IsNotExist(err) {
+					fullbuilddirectory = fullappdirectory
+				} else {
+					log.Debugf("Path to app directory %s does not exist, assuming manifest directory as app path", fullappdirectory)
+				}
 			}
 			applicationName := application.Name
 			if applicationName == "" {


### PR DESCRIPTION
Signed-off-by: Ashok Pon Kumar <ashokponkumar@gmail.com>
