### PR TITLE
feat: write release information to a file

### DIFF
--- a/.github/workflows/releaseinfo.yml
+++ b/.github/workflows/releaseinfo.yml
@@ -1,0 +1,26 @@
+name: write release information to file
+
+on: workflow_dispatch
+
+jobs:
+  release_info:
+    runs-on: ubuntu-latest
+    steps:
+      - id: info
+        uses: HarikrishnanBalagopal/nextrelease@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+      - run: echo '${{ steps.info.outputs.release_info }}' > releaseinfo.json
+      - uses: EndBug/add-and-commit@v6
+        with:
+          add: releaseinfo.json
+          author_name: move2kube
+          author_email: move2kube@gmail.com
+          branch: gh-pages
+          cwd: "."
+          message: "chore: update release information. run_id ${{ github.run_id }}"
+          pull_strategy: "--ff-only"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/releaseinfo.yml
+++ b/.github/workflows/releaseinfo.yml
@@ -7,16 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: info
-        uses: HarikrishnanBalagopal/nextrelease@v1
+        uses: konveyor/get-release-info@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
         with:
           ref: gh-pages
-      - run: echo '${{ steps.info.outputs.release_info }}' > releaseinfo.json
+      - run: echo '${{ steps.info.outputs.release_info }}' > _data/releaseinfo.json
       - uses: EndBug/add-and-commit@v6
         with:
-          add: releaseinfo.json
+          add: _data/releaseinfo.json
           author_name: move2kube
           author_email: move2kube@gmail.com
           branch: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ bin
 coverage.txt
 .jekyll-cache/
 _site/
+node_modules


### PR DESCRIPTION
This info will be displayed on the website.
This info will also be used by the release
UI to decide the tag, commit, etc. to use
for new releases.

Also ignore node_modules in main branch to
allow easy switching to and from gh-pages.

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>