### PR TITLE
ci: create branch if necessary in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,11 +101,28 @@ jobs:
         with:
           github-token: ${{ secrets.MOVE2KUBE_PATOKEN }}
           script: |
+            const tag = '${{ github.event.inputs.tag }}';
+            const sha = '${{ steps.get_sha.outputs.sha }}';
+            // create the tag
             github.git.createRef({
               ...context.repo,
-              ref: "refs/tags/${{ github.event.inputs.tag }}",
-              sha: "${{ steps.get_sha.outputs.sha }}"
-            })
+              ref: `refs/tags/${tag}`,
+              sha
+            });
+            if(!tag.endsWith('-beta.0')) {
+              return;
+            }
+            // create the release branch
+            const major_minor = /^v(\d+\.\d+)/.exec(tag);
+            if(!major_minor || major_minor.length !== 2){
+              return core.setFailed(`The tag is not a valid semantic version. tag: ${tag}`);
+            }
+            const branch_name = `release-${major_minor[1]}`;
+            github.git.createRef({
+              ...context.repo,
+              ref: `refs/heads/${branch_name}`,
+              sha
+            });
 
   create_release_draft:
     needs: [tag]
@@ -236,3 +253,24 @@ jobs:
           repository: ${{ matrix.repo }}
           event-type: cli_tagged
           client-payload: '{"tag": "${{ github.event.inputs.tag }}", "prev_tag": "${{ github.event.inputs.prev_tag }}", "commit_ref": "${{ github.event.inputs.commit_ref }}" }'
+
+  update_draft_title:
+    needs: [create_release_draft, trigger_other_repos]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.MOVE2KUBE_PATOKEN }}
+          script: |
+            const tag = '${{ github.event.inputs.tag }}';
+            const response = await github.repos.listReleases({ ...context.repo });
+            const drafts = response.data.filter(release => release.draft && release.tag_name === tag);
+            if(drafts.length !== 1) {
+              return core.setFailed(`Expected to find exactly one draft release with the tag ${tag}. Found: ${drafts.length}`);
+            }
+            const draft = drafts[0];
+            if(!draft.name.startsWith('[WIP] ')) {
+              return core.setFailed(`Expected the draft name to begin with [WIP]. Found: ${draft.name}`);
+            }
+            const new_name = draft.name.replace(/^\[WIP\] /, '');
+            await github.repos.updateRelease({...context.repo, release_id: draft.id, name: new_name});

--- a/.grenrc.js
+++ b/.grenrc.js
@@ -14,7 +14,7 @@ function printPreambleAndGroupName({ heading }) {
 
 module.exports = {
   "dataSource": "prs",
-  "prefix": "Move2Kube ",
+  "prefix": "[WIP] Move2Kube ",
   // valid PR types: ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'build', 'ci', 'chore', 'revert']
   "groupBy":
   {


### PR DESCRIPTION
Also use the draft title as a mutex.
The title will have the prefix [WIP]
while the workflow is in progress.
The UI will detect this and not allow
publishing the draft.

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>