### PR TITLE
fix: .brew_home is created during brew bottling causing git tree state to become dirty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ coverage.txt
 .jekyll-cache/
 _site/
 node_modules
+
+# brew bottling creates .brew_home directory
+# add this to avoid git tree start becoming dirty
+.brew_home/


### PR DESCRIPTION
Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>