### PR TITLE
fix: arguments to IsParent were switched

### DIFF
--- a/cmd/common/utils.go
+++ b/cmd/common/utils.go
@@ -90,7 +90,7 @@ func CheckSourcePath(srcpath string) {
 	if err != nil {
 		log.Fatalf("Failed to get the current working directory. Error: %q", err)
 	}
-	if internalcommon.IsParent(srcpath, pwd) {
+	if internalcommon.IsParent(pwd, srcpath) {
 		log.Fatalf("The given source directory %s is a parent of the current working directory.", srcpath)
 	}
 }
@@ -115,7 +115,7 @@ func CheckOutputPath(outpath string, overwrite bool) {
 	if err != nil {
 		log.Fatalf("Failed to get the current working directory. Error: %q", err)
 	}
-	if internalcommon.IsParent(outpath, pwd) {
+	if internalcommon.IsParent(pwd, outpath) {
 		log.Fatalf("The given output directory %s is a parent of the current working directory.", outpath)
 	}
 	log.Infof("Output directory %s exists. The contents might get overwritten.", outpath)

--- a/cmd/kubectltranslate/kubectltranslate.go
+++ b/cmd/kubectltranslate/kubectltranslate.go
@@ -52,6 +52,9 @@ func translateHandler(cmd *cobra.Command, flags cmdcommon.TranslateFlags) {
 	cmdcommon.CheckSourcePath(flags.Srcpath)
 	flags.Outpath = filepath.Join(flags.Outpath, flags.Name)
 	cmdcommon.CheckOutputPath(flags.Outpath, flags.Overwrite)
+	if flags.Srcpath == flags.Outpath || common.IsParent(flags.Outpath, flags.Srcpath) {
+		log.Fatalf("The source path %s and output path %s overlap.", flags.Srcpath, flags.Outpath)
+	}
 	if err := os.MkdirAll(flags.Outpath, common.DefaultDirectoryPermission); err != nil {
 		log.Fatalf("Failed to create the output directory at path %s Error: %q", flags.Outpath, err)
 	}

--- a/cmd/kubectltranslate/kubectltranslate.go
+++ b/cmd/kubectltranslate/kubectltranslate.go
@@ -52,7 +52,7 @@ func translateHandler(cmd *cobra.Command, flags cmdcommon.TranslateFlags) {
 	cmdcommon.CheckSourcePath(flags.Srcpath)
 	flags.Outpath = filepath.Join(flags.Outpath, flags.Name)
 	cmdcommon.CheckOutputPath(flags.Outpath, flags.Overwrite)
-	if flags.Srcpath == flags.Outpath || common.IsParent(flags.Outpath, flags.Srcpath) {
+	if flags.Srcpath == flags.Outpath || common.IsParent(flags.Outpath, flags.Srcpath) || common.IsParent(flags.Srcpath, flags.Outpath) {
 		log.Fatalf("The source path %s and output path %s overlap.", flags.Srcpath, flags.Outpath)
 	}
 	if err := os.MkdirAll(flags.Outpath, common.DefaultDirectoryPermission); err != nil {

--- a/cmd/move2kube/translate.go
+++ b/cmd/move2kube/translate.go
@@ -83,7 +83,7 @@ func translateHandler(cmd *cobra.Command, flags translateFlags) {
 		cmdcommon.CheckSourcePath(flags.Srcpath)
 		flags.Outpath = filepath.Join(flags.Outpath, flags.Name)
 		cmdcommon.CheckOutputPath(flags.Outpath, flags.Overwrite)
-		if flags.Srcpath == flags.Outpath || common.IsParent(flags.Outpath, flags.Srcpath) {
+		if flags.Srcpath == flags.Outpath || common.IsParent(flags.Outpath, flags.Srcpath) || common.IsParent(flags.Srcpath, flags.Outpath) {
 			log.Fatalf("The source path %s and output path %s overlap.", flags.Srcpath, flags.Outpath)
 		}
 		if err := os.MkdirAll(flags.Outpath, common.DefaultDirectoryPermission); err != nil {
@@ -125,7 +125,7 @@ func translateHandler(cmd *cobra.Command, flags translateFlags) {
 		cmdcommon.CheckSourcePath(p.Spec.Inputs.RootDir)
 		flags.Outpath = filepath.Join(flags.Outpath, p.Name)
 		cmdcommon.CheckOutputPath(flags.Outpath, flags.Overwrite)
-		if p.Spec.Inputs.RootDir == flags.Outpath || common.IsParent(flags.Outpath, p.Spec.Inputs.RootDir) {
+		if p.Spec.Inputs.RootDir == flags.Outpath || common.IsParent(flags.Outpath, p.Spec.Inputs.RootDir) || common.IsParent(p.Spec.Inputs.RootDir, flags.Outpath) {
 			log.Fatalf("The source path %s and output path %s overlap.", p.Spec.Inputs.RootDir, flags.Outpath)
 		}
 		if err := os.MkdirAll(flags.Outpath, common.DefaultDirectoryPermission); err != nil {


### PR DESCRIPTION
also add the check to kubectl-translate plugin

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>