### PR TITLE
chore: fix an issue with upx and mac where the process gets killed immediately

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ steps.info.outputs.go_version }}
-      - name: install upx to compress binaries
-        run: sudo apt-get install -y upx
       - run: make ci
       - run: make test-coverage
       - name: upload coverage

--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -17,8 +17,6 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ steps.info.outputs.go_version }}
-      - name: install upx to compress binaries
-        run: sudo apt-get install -y upx
       - run: make ci
       - run: make test-coverage
       - name: upload coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,12 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ steps.info.outputs.go_version }}
-      - name: install upx to compress binaries
-        run: sudo apt-get install -y upx
+
+      - name: install upx ^3.96 to compress binaries. The default 3.94 version has some issues with MacOS.
+        run: brew install upx
+      - run: ls -al "$(which upx)"
+      - run: upx --version
+
       - run: make ci
       - run: make test-coverage
       - name: upload coverage
@@ -167,8 +171,12 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ steps.info.outputs.go_version }}
-      - name: install upx to compress binaries
-        run: sudo apt-get install -y upx
+
+      - name: install upx ^3.96 to compress binaries. The default 3.94 version has some issues with MacOS.
+        run: brew install upx
+      - run: ls -al "$(which upx)"
+      - run: upx --version
+
       - run: VERSION='${{ github.event.inputs.tag }}' make dist
       - name: upload release assets
         uses: HarikrishnanBalagopal/upload-release-action@v3


### PR DESCRIPTION
Issue seems to be with v3.94 of upx that comes installed by
default in ubuntu-latest images of Github actions.

A number of very similar issues:
https://github.com/upx/upx/issues/450
https://github.com/upx/upx/issues/222

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>