### PR TITLE
chore: github only allows some whitelisted plugins, so remove the plugin and add gtm tag manually

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 gemspec
 gem "jekyll-remote-theme"
-group :jekyll_plugins do
-  gem 'jekyll-google-tag-manager'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,8 +37,6 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 1.8)
-    jekyll-google-tag-manager (1.0.3)
-      jekyll (>= 3.3, < 5.0)
     jekyll-remote-theme (0.4.2)
       addressable (~> 2.0)
       jekyll (>= 3.5, < 5.0)
@@ -81,7 +79,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.1.4)
-  jekyll-google-tag-manager
   jekyll-remote-theme
   just-the-docs!
 

--- a/_config.yml
+++ b/_config.yml
@@ -98,9 +98,7 @@ color_scheme: konveyor
 #    title: "&nbsp;&emsp;&emsp;Slack"
 
 # Google Tag Manager
-google:
-  tag_manager:
-    container_id: GTM-TKPDMS3
+gtm_container_id: GTM-TKPDMS3
 
 plugins:
   - jekyll-seo-tag

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,4 @@
 <head>
-  {% gtm head %}
-
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 
@@ -27,4 +25,13 @@
 
   {% include head_custom.html %}
 
+  {% if jekyll.environment == 'production' and site.gtm_container_id %}
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','{{ site.gtm_container_id }}');</script>
+  <!-- End Google Tag Manager -->
+  {% endif %}
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,13 @@ layout: table_wrappers
 <html lang="{{ site.lang | default: 'en-US' }}">
 {% include head.html %}
 <body>
-  {% gtm body %}
+  {% if jekyll.environment == 'production' and site.gtm_container_id %}
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id={{ site.gtm_container_id }}" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  {% endif %}
 
   <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
     <symbol id="svg-link" viewBox="0 0 24 24">


### PR DESCRIPTION
GitHub builds the website using the --safe option as mentioned here:
https://jekyllrb.com/docs/plugins/installation/

So only some plugins are allowed. The complete list of whitelisted
plugins is given here: https://pages.github.com/versions/

The google tag manager plugin https://github.com/t-richards/jekyll-google-tag-manager
is not listed there.

Fix is to remove the plugin and add the tag manually.

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>