### PR TITLE
fix: github only supports a small list of themes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@
 # you will see them accessed via {{ site.title }}, {{ site.github_repo }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-theme: just-the-docs
+remote_theme: pmarsceill/just-the-docs
 title: Konveyor MoveKube
 description: A tool that accelerates the process of re-platforming to Kubernetes
 baseurl: "/" # the subpath of your site, e.g. /blog


### PR DESCRIPTION
See https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site-using-jekyll#adding-a-theme

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>