### PR TITLE
fix: remove just-the-docs theme from gemfile and let the jekyll-remote-theme plugin take care of it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
-gem "just-the-docs"
+gem 'rake'
 gem "jekyll-remote-theme"
+gem 'jekyll-seo-tag'
 
 gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,10 +40,6 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    just-the-docs (0.3.3)
-      jekyll (>= 3.8.5)
-      jekyll-seo-tag (~> 2.0)
-      rake (>= 12.3.1, < 13.1.0)
     kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -76,7 +72,8 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll-remote-theme
-  just-the-docs
+  jekyll-seo-tag
+  rake
   webrick (~> 1.7)
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -102,6 +102,7 @@ color_scheme: konveyor
 gtm_container_id: GTM-TKPDMS3
 
 plugins:
+  - jekyll-remote-theme
   - jekyll-seo-tag
 
 compress_html:


### PR DESCRIPTION
Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>