### PR TITLE
fix: Prevent crash when all transformers for a service become unselected

### DIFF
--- a/api/planner.go
+++ b/api/planner.go
@@ -133,7 +133,8 @@ func CuratePlan(p plantypes.Plan) plantypes.Plan {
 			modes = append(modes, mode)
 		}
 		if len(sTransformers) == 0 {
-			logrus.Errorf("No transformers selected for service %s. Ignoring.", sn)
+			logrus.Warnf("No transformers selected for service %s. Ignoring.", sn)
+			delete(p.Spec.Services, sn)
 			continue
 		}
 		p.Spec.Services[sn] = sTransformers


### PR DESCRIPTION
Signed-off-by: Ashok Pon Kumar <ashokponkumar@gmail.com>
