### PR TITLE
fix: Target windows node if the dockerfile template is windows platform based

### DIFF
--- a/internal/transformer/classes/analysers/dockerfileparser.go
+++ b/internal/transformer/classes/analysers/dockerfileparser.go
@@ -181,8 +181,11 @@ func (t *DockerfileParser) isWindowsContainer(df *dockerparser.Result) bool {
 			if imageNameNode == nil {
 				continue
 			}
-			if strings.HasPrefix(imageNameNode.Value, "mcr.microsoft.com") {
-				return true
+			for _, flag := range dfchild.Flags {
+				flag = strings.TrimPrefix(flag, "--platform=")
+				if strings.HasPrefix(flag, "windows") {
+					return true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Example: 

 - `FROM mcr.microsoft.com/dotnet/sdk:5.0 AS buildImg` -Select linux container
 -  `FROM --platform=windows/amd4 mcr.microsoft.com/dotnet/sdk:5.0 AS buildImg`- Select windows container

Signed-off-by: Akash Nayak <akash19nayak@gmail.com>