### PR TITLE
feat: Use docker or podman to start a local container

### DIFF
--- a/docs/installation/web-interface.md
+++ b/docs/installation/web-interface.md
@@ -10,39 +10,79 @@ nav_order: 2
 
 ## Bringing up Move2Kube all-in-one container
 
-**Stable Release**
-   ```console
-   $ mkdir -p workspace 
-   $ cd workspace
-   $ docker run -p 8080:8080 -v "${PWD}:/workspace" -v /var/run/docker.sock:/var/run/docker.sock --rm -it quay.io/konveyor/move2kube-aio:release-0.2
-   ```
+Choose the version ready for you use case:
 
-**Latest** 
-   ```console
-   $ mkdir -p workspace
-   $ cd workspace
-   $ docker run -p 8080:8080 -v "${PWD}:/workspace" -v /var/run/docker.sock:/var/run/docker.sock --rm -it quay.io/konveyor/move2kube-aio:latest
-   ```
-   Access the UI in `http://localhost:8080/`.
+**Stable Release** ready for production cases:
+
+To run locally using `docker`:
+
+```shell
+$ mkdir -p workspace 
+$ cd workspace
+$ docker run -p 8080:8080 -v "${PWD}:/workspace" -v /var/run/docker.sock:/var/run/docker.sock --rm -it quay.io/konveyor/move2kube-aio:release-0.2
+```
+
+To run locally using `podman`:
+
+```shell
+$ mkdir -p workspace 
+$ cd workspace
+$ podman run -p 8080:8080 -v "${PWD}:/workspace:z" --rm -it quay.io/konveyor/move2kube-aio:release-0.2
+```
+
+**Latest** for development and testing cases:
+
+To run locally using `docker`:
+
+```shell
+$ mkdir -p workspace
+$ cd workspace
+$ docker run -p 8080:8080 -v "${PWD}:/workspace" -v /var/run/docker.sock:/var/run/docker.sock --rm -it quay.io/konveyor/move2kube-aio:latest
+```
+
+To run locally using `podman`:
+
+```shell
+$ mkdir -p workspace
+$ cd workspace
+$ podman run -p 8080:8080 -v "${PWD}:/workspace:z" --rm -it quay.io/konveyor/move2kube-aio:latest
+```
+
+Access the UI in `http://localhost:8080/`.
 
    > Note: There is a known issue when using the above command in WSL.  
-   The CNB containerization option will not be availabe.  
+   The CNB containerization option will not be available.  
    Also an empty folder called `workspace` may be created in the root directory.  
    If you are on Windows, use Powershell instead of WSL until this is fixed.
 
 ## Bringing up Move2Kube UI and API as separate containers
 
-   ```console
-   $ git clone https://github.com/konveyor/move2kube-ui
-   $ cd move2kube-ui
-   $ docker-compose up
-   ```
-   Access the UI in `http://localhost:8080/`.
+Cloning the git repository:
 
+```shell
+$ git clone https://github.com/konveyor/move2kube-ui
+$ cd move2kube-ui
+$ mkdir -p data
+```
+
+The `data` folder will be used to persist the data managed by the container.
+
+Start the container using `docker-compose`:
+
+```shell
+$ docker-compose up
+```
+
+Or using `podman-compose`:
+
+```shell
+$ podman-compose -f podman-compose.yml up
+```
+
+Access the UI in `http://localhost:8080/`.
 
 ## Bringing up Move2Kube UI as Helm Chart  
-   Move2Kube can also be installed as a Helm Chart from [ArtifactHub](https://artifacthub.io/packages/helm/move2kube/move2kube/0.2.0-beta.0?modal=install)
 
-   Also, for Helm Chart and Operator checkout [Move2Kube Operator](https://github.com/konveyor/move2kube-operator).
+Move2Kube can also be installed as a Helm Chart from [ArtifactHub](https://artifacthub.io/packages/helm/move2kube/move2kube/0.2.0-beta.0?modal=install)
 
-<br>
+Also, for Helm Chart and Operator checkout [Move2Kube Operator](https://github.com/konveyor/move2kube-operator).


### PR DESCRIPTION
This PR adds documentation about how to use `docker` or `podman` to start locally a container.

Also the documentation is aligned with other changes proposed in the move2kube-ui project in the PR https://github.com/konveyor/move2kube-ui/pull/106. 

This PR should be approved when the previous one was done (to align documentation and assess).

Signed-off-by: Roman Martin <rmarting@redhat.com>