### PR TITLE
refactor: added the error to the log messages when processing path mappings

### DIFF
--- a/transformer/processors.go
+++ b/transformer/processors.go
@@ -60,16 +60,16 @@ func processPathMappings(pms []transformertypes.PathMapping, sourcePath, outputP
 		case strings.ToLower(transformertypes.SourcePathMappingType): // skip sources
 		case strings.ToLower(transformertypes.ModifiedSourcePathMappingType):
 			if err := filesystem.Merge(pm.SrcPath, destPath, false); err != nil {
-				logrus.Errorf("Error while copying sourcepath for %+v", pm)
+				logrus.Errorf("Error while copying sourcepath for %+v . Error: %q", pm, err)
 			}
 		case strings.ToLower(transformertypes.TemplatePathMappingType):
 			if err := filesystem.TemplateCopy(pm.SrcPath, destPath, pm.TemplateConfig); err != nil {
-				logrus.Errorf("Error while copying sourcepath for %+v", pm)
+				logrus.Errorf("Error while copying sourcepath for %+v . Error: %q", pm, err)
 			}
 		default:
 			if !copiedDefaultDests[getpair(pm.SrcPath, pm.DestPath)] {
 				if err := filesystem.Merge(pm.SrcPath, destPath, false); err != nil {
-					logrus.Errorf("Error while copying sourcepath for %+v", pm)
+					logrus.Errorf("Error while copying sourcepath for %+v . Error: %q", pm, err)
 				}
 				copiedDefaultDests[getpair(pm.SrcPath, pm.DestPath)] = true
 			}


### PR DESCRIPTION
This PR adds the returned errors to the log message. It should help to clarify the somewhat ambiguous/identical log messages. It appears that there are multiple reasons for an error to occur. For example, the `process` function which gets called when doing a `TemplateCopy` could error in multiple ways while processing a file, symlink or directory. The uniqueness of the possible errors can be valuable in situations where we'd need to debug using these log messages.