### PR TITLE
fix: bug where 2 questions about port are asked

### DIFF
--- a/assets/inbuilt/transformers/dockerfilegenerator/java/earrouter/earrouter.yaml
+++ b/assets/inbuilt/transformers/dockerfilegenerator/java/earrouter/earrouter.yaml
@@ -11,6 +11,7 @@ spec:
   consumes: 
     Ear:
       merge: true
+      mode: "MandatoryPassThrough"
   produces: 
     Ear:
       disabled: false

--- a/assets/inbuilt/transformers/dockerfilegenerator/java/warrouter/warrouter.yaml
+++ b/assets/inbuilt/transformers/dockerfilegenerator/java/warrouter/warrouter.yaml
@@ -11,6 +11,7 @@ spec:
   consumes: 
     War:
       merge: true
+      mode: "MandatoryPassThrough"
   produces: 
     War:
       disabled: false


### PR DESCRIPTION
When "intercepts" was changed to "passthrough" concept,
some of the built-in transformer yamls were not updated properly with the new field.
The WAR router transformer was running in parallel with the
WAR processor transformers (JBoss, Liberty, Tomcat).
This causes extra questions to be asked and ports 8080 and 9080 to come up together.

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>