### PR TITLE
fix: panic during QA when transforming some apps like train-ticket

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -55,7 +55,7 @@ func GetYamlsWithTypeMeta(inputPath string, kindFilter string) ([]string, error)
 	var result []string
 	fileList, err := GetFilesByExt(inputPath, []string{".yaml", ".yml"})
 	if err != nil {
-		return nil, fmt.Errorf("Could not retrieve yaml files from path [%s]", inputPath)
+		return nil, fmt.Errorf("could not retrieve yaml files from path [%s]", inputPath)
 	}
 	for _, filePath := range fileList {
 		var preamble types.TypeMeta
@@ -514,6 +514,10 @@ func NormalizeForFilename(name string) string {
 
 // NormalizeForMetadataName converts the string to be compatible for service name
 func NormalizeForMetadataName(metadataName string) string {
+	if metadataName == "" {
+		logrus.Errorf("failed to normalize for service/metadata name because it is an empty string")
+		return ""
+	}
 	newName := disallowedDNSCharactersRegex.ReplaceAllLiteralString(strings.ToLower(metadataName), "-")
 	maxLength := 63
 	if len(newName) > maxLength {
@@ -521,7 +525,7 @@ func NormalizeForMetadataName(metadataName string) string {
 	}
 	newName = ReplaceStartingTerminatingHyphens(newName, "a", "z")
 	if newName != metadataName {
-		logrus.Infof("Changing metadata name to %s from %s", metadataName, newName)
+		logrus.Infof("Changing metadata name from %s to %s", metadataName, newName)
 	}
 	return newName
 }
@@ -535,7 +539,7 @@ func NormalizeForEnvironmentVariableName(envName string) string {
 		newName = characterToMakeValid + newName
 	}
 	if newName != envName {
-		logrus.Infof("Changing environment name to %s from %s", envName, newName)
+		logrus.Infof("Changing environment name from %s to %s", envName, newName)
 	}
 	return newName
 }
@@ -1268,7 +1272,7 @@ func ConvertStringSelectorsToSelectors(transformerSelector string) (labels.Selec
 }
 
 // ReplaceStartingTerminatingHyphens replaces the first and last characters of a string if they are hyphens
-func ReplaceStartingTerminatingHyphens(str string, startReplaceStr, endReplaceStr string) string {
+func ReplaceStartingTerminatingHyphens(str, startReplaceStr, endReplaceStr string) string {
 	first := str[0]
 	last := str[len(str)-1]
 	if first == '-' {

--- a/transformer/dockerfilegenerator/pythondockerfiletransformer.go
+++ b/transformer/dockerfilegenerator/pythondockerfiletransformer.go
@@ -231,8 +231,14 @@ func (t *PythonDockerfileGenerator) Transform(newArtifacts []transformertypes.Ar
 			ports = []int32{common.DefaultServicePort}
 		}
 		pythonTemplateConfig.Port = commonqa.GetPortForService(ports, a.Name)
-		if requirementsTxt, err := filepath.Rel(a.Paths[artifacts.ServiceDirPathType][0], a.Paths[RequirementsTxtPathType][0]); err == nil {
-			pythonTemplateConfig.RequirementsTxt = requirementsTxt
+		if len(a.Paths[artifacts.ServiceDirPathType]) == 0 {
+			logrus.Errorf("The service directory path is missing for the artifact: %+v", a)
+			continue
+		}
+		if len(a.Paths[RequirementsTxtPathType]) != 0 {
+			if requirementsTxt, err := filepath.Rel(a.Paths[artifacts.ServiceDirPathType][0], a.Paths[RequirementsTxtPathType][0]); err == nil {
+				pythonTemplateConfig.RequirementsTxt = requirementsTxt
+			}
 		}
 		if sImageName.ImageName == "" {
 			sImageName.ImageName = common.MakeStringContainerImageNameCompliant(sConfig.ServiceName)


### PR DESCRIPTION
# BUG


```
$ move2kube plan -s train-ticket/
INFO[0000] Configuration loading done                   
INFO[0000] Planning Transformation - Base Directory     
INFO[0000] [CloudFoundry] Planning transformation       
INFO[0000] [CloudFoundry] Done                          
INFO[0000] [ComposeAnalyser] Planning transformation    
INFO[0000] Identified 69 named services and 0 to-be-named services 
INFO[0000] [ComposeAnalyser] Done                       
INFO[0000] [DockerfileDetector] Planning transformation 
INFO[0002] Identified 1 named services and 42 to-be-named services 
INFO[0002] [DockerfileDetector] Done                    
INFO[0002] [Base Directory] Identified 70 named services and 42 to-be-named services 
INFO[0002] Transformation planning - Base Directory done 
INFO[0002] Planning Transformation - Directory Walk     
INFO[0002] Identified 1 named services and 0 to-be-named services in . 
INFO[0002] Transformation planning - Directory Walk done 
INFO[0002] [Directory Walk] Identified 70 named services and 43 to-be-named services 
INFO[0002] [Named Services] Identified 72 named services 
INFO[0002] No of services identified : 72               
INFO[0002] Plan can be found at [/Users/user/temp/testbug/m2k.plan]. 
$ move2kube transform
INFO[0000] Detected a plan file at path /Users/user/temp/testbug/m2k.plan. Will transform using this plan. 
INFO[0000] Starting Plan Transformation                 
? Select all transformer types that you are interested in:
ID: move2kube.transformers.types
Hints:
[Services that don't support any of the transformer types you are interested in will be ignored.]
 Buildconfig, CloudFoundry, ClusterSelector, ComposeAnalyser, ComposeGenerator, ContainerImagesPushScriptGenerator, DockerfileDetector, DockerfileImageBuildScript, DockerfileParser, DotNetCore-Dockerfile, EarAnalyser, EarRouter, Golang-Dockerfile, Gradle, Jar, Jboss, Knative, Kubernetes, KubernetesVersionChanger, Liberty, Maven, Nodejs-Dockerfile, PHP-Dockerfile, Parameterizer, Python-Dockerfile, ReadMeGenerator, Ruby-Dockerfile, Rust-Dockerfile, Tekton, Tomcat, WarAnalyser, WarRouter, WinConsoleApp-Dockerfile, WinSLWebApp-Dockerfile, WinWebApp-Dockerfile, ZuulAnalyser
? Select all services that are needed:
ID: move2kube.services.[].enable
Hints:
[The services unselected here will be ignored.]
 jaeger, redis, train-ticket, train-ticket-ts-avatar-service, train-ticket-ts-delivery-service, ts-account-mongo, ts-admin-basic-info-service, ts-admin-order-service, ts-admin-route-service, ts-admin-travel-service, ts-admin-user-service, ts-assurance-mongo, ts-assurance-service, ts-auth-mongo, ts-auth-service, ts-avatar-service, ts-basic-service, ts-cancel-service, ts-config-mongo, ts-config-service, ts-consign-mongo, ts-consign-price-mongo, ts-consign-price-service, ts-consign-service, ts-contacts-mongo, ts-contacts-service, ts-execute-service, ts-food-map-mongo, ts-food-map-service, ts-food-mongo, ts-food-service, ts-inside-payment-mongo, ts-inside-payment-service, ts-news-mongo, ts-news-service, ts-notification-service, ts-order-mongo, ts-order-other-mongo, ts-order-other-service, ts-order-service, ts-payment-mongo, ts-payment-service, ts-preserve-other-service, ts-preserve-service, ts-price-mongo, ts-price-service, ts-rebook-mongo, ts-rebook-service, ts-route-mongo, ts-route-plan-service, ts-route-service, ts-seat-service, ts-security-mongo, ts-security-service, ts-station-mongo, ts-station-service, ts-ticket-office-mongo, ts-ticket-office-service, ts-ticketinfo-service, ts-train-mongo, ts-train-service, ts-travel-mongo, ts-travel-plan-service, ts-travel-service, ts-travel2-mongo, ts-travel2-service, ts-ui-dashboard, ts-user-mongo, ts-user-service, ts-verification-code-service, ts-voucher-mysql, ts-voucher-service
INFO[0001] Iteration 1                                  
INFO[0001] Iteration 2 - 72 artifacts to process        
INFO[0001] Transformer ComposeAnalyser processing 69 artifacts 
INFO[0001] DEBUG NormalizeForMetadataName start jaeger  
INFO[0001] DEBUG NormalizeForMetadataName newName 6 jaeger 
INFO[0001] DEBUG ReplaceStartingTerminatingHyphens start jaeger a z 
INFO[0001] DEBUG ReplaceStartingTerminatingHyphens len(str) 6 jaeger 
INFO[0001] DEBUG ReplaceStartingTerminatingHyphens len(str) 6 jaeger 
INFO[0001] DEBUG ReplaceStartingTerminatingHyphens end  
INFO[0001] DEBUG NormalizeForMetadataName newName again 6 jaeger 
INFO[0001] DEBUG NormalizeForMetadataName end           
INFO[0001] DEBUG NormalizeForMetadataName start         
INFO[0001] DEBUG NormalizeForMetadataName newName 0     
INFO[0001] DEBUG ReplaceStartingTerminatingHyphens start  a z 
INFO[0001] DEBUG ReplaceStartingTerminatingHyphens len(str) 0  
INFO[0001] DEBUG ReplaceStartingTerminatingHyphens end  
INFO[0001] DEBUG NormalizeForMetadataName end           
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/konveyor/move2kube/common.ReplaceStartingTerminatingHyphens({0x0, 0x0}, {0x31c163d, 0x1}, {0x31c1651, 0x1})
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/common/utils.go:1279 +0x465
github.com/konveyor/move2kube/common.NormalizeForMetadataName({0x0, 0xc000e208d0})
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/common/utils.go:525 +0x1f8
github.com/konveyor/move2kube/transformer/compose.(*v3Loader).convertToIR(0xc000ce36a8, {0xc000f69650, 0x49}, {{0xc000f69650, 0x68}, {0x31c1c25, 0x3}, {0xc000a12000, 0x44, 0x48}, ...}, ...)
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/transformer/compose/v3.go:177 +0x88d
github.com/konveyor/move2kube/transformer/compose.(*v3Loader).ConvertToIR(0xc000433cd8, {0xc000f69650, 0x68}, {0xc000433cd8, 0x6})
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/transformer/compose/v3.go:130 +0x285
github.com/konveyor/move2kube/transformer/compose.(*ComposeAnalyser).Transform(0xc0000da2d0, {0xc000eda000, 0x45, 0x26}, {0xc000ce46e0, 0x2, 0x2})
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/transformer/compose/composeanalyser.go:120 +0x17b4
github.com/konveyor/move2kube/transformer.runSingleTransform({0xc000e49500, 0x45, _}, {_, _, _}, {_, _}, {{{0xc000d408c0, 0x1e}, ...}, ...}, ...)
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/transformer/transformer.go:469 +0x292
github.com/konveyor/move2kube/transformer.transform({0xc000dac000, 0xc000000004, 0x3218689}, {0xc000dac000, 0x48, 0x88}, 0x0, {0x0, 0x0})
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/transformer/transformer.go:426 +0xb12
github.com/konveyor/move2kube/transformer.Transform({0xc000d50000, 0x48, 0xc000daa6f0}, {0xc000058a80, 0x25}, {0xc000059470, 0x22})
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/transformer/transformer.go:385 +0x295
github.com/konveyor/move2kube/lib.Transform({0xc0000591d0, 0x21}, {{{0xc0005f5060, 0x1e}, {0xc000433bfc, 0x4}}, {{0xc000433c24, 0x9}, 0x0}, {{0xc000058a80, ...}, ...}}, ...)
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/lib/transformer.go:73 +0x57c
github.com/konveyor/move2kube/cmd.transformHandler(_, {{0x0, 0x0, {0x3370a38, 0x1}, {0x3370a38, 0x1}, {0x4c74bc0, 0x0, 0x0}, ...}, ...})
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/cmd/transform.go:151 +0x11ee
github.com/konveyor/move2kube/cmd.GetTransformCommand.func2(0xc000130000, {0x31c2cac, 0x0, 0x0})
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/cmd/transform.go:169 +0x58
github.com/spf13/cobra.(*Command).execute(0xc000130000, {0x4c74bc0, 0x0, 0x0})
	/Users/user/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:860 +0x5f8
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000d9400)
	/Users/user/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/user/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:902
main.main()
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/main.go:43 +0x21b
```


Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>