### PR TITLE
fix: empty metadata.name or service name when transforming docker compose with volume

### DIFF
--- a/transformer/compose/v3.go
+++ b/transformer/compose/v3.go
@@ -408,20 +408,28 @@ func (c *v3Loader) convertToIR(filedir string, composeObject types.Config, servi
 					},
 				})
 			} else {
+				// Generate a hash Id for the given source file path to be mounted.
+				hPath := vol.Source
+				if hPath == "" {
+					hPath = vol.Target
+				}
+				hashID := getHash([]byte(hPath))
+				volumeName := fmt.Sprintf("%s%d", common.VolumePrefix, hashID)
+
 				serviceContainer.VolumeMounts = append(serviceContainer.VolumeMounts, core.VolumeMount{
-					Name:      vol.Source,
+					Name:      volumeName,
 					MountPath: vol.Target,
 				})
 
 				serviceConfig.AddVolume(core.Volume{
-					Name: vol.Source,
+					Name: volumeName,
 					VolumeSource: core.VolumeSource{
 						PersistentVolumeClaim: &core.PersistentVolumeClaimVolumeSource{
-							ClaimName: vol.Source,
+							ClaimName: volumeName,
 						},
 					},
 				})
-				storageObj := irtypes.Storage{StorageType: irtypes.PVCKind, Name: vol.Source, Content: nil}
+				storageObj := irtypes.Storage{StorageType: irtypes.PVCKind, Name: volumeName, Content: nil}
 				ir.AddStorage(storageObj)
 			}
 		}

--- a/transformer/kubernetes/apiresource/storage.go
+++ b/transformer/kubernetes/apiresource/storage.go
@@ -186,7 +186,6 @@ func convertVolumeBySupportedKind(volume core.Volume, cluster collecttypes.Clust
 			vEmpty := convertPVCVolumeToEmptyVolume(volume)
 			logrus.Warnf("PVC not supported in target cluster. Defaulting volume [%s] to emptyDir", volume.Name)
 			return *vEmpty
-
 		}
 		return volume
 	}

--- a/transformer/kubernetes/k8sschema/utils.go
+++ b/transformer/kubernetes/k8sschema/utils.go
@@ -52,7 +52,7 @@ func Intersection(objs1 []runtime.Object, objs2 []runtime.Object) []runtime.Obje
 }
 
 // GetInfoFromK8sResource returns some useful information given a k8s resource
-func GetInfoFromK8sResource(k8sResource K8sResourceT) (kind string, apiVersion string, name string, err error) {
+func GetInfoFromK8sResource(k8sResource K8sResourceT) (kind, apiVersion, name string, err error) {
 	logrus.Trace("start getInfoFromK8sResource")
 	defer logrus.Trace("end getInfoFromK8sResource")
 	kindI, ok := k8sResource["kind"]

--- a/transformer/kubernetes/parameterizertransformer.go
+++ b/transformer/kubernetes/parameterizertransformer.go
@@ -127,10 +127,12 @@ func (t *Parameterizer) Transform(newArtifacts []transformertypes.Artifact, alre
 			logrus.Errorf("Unable to evaluate helm chart name : %s", err)
 			continue
 		}
-		pt := parameterizer.ParameterizerConfigT{Helm: "helm",
+		pt := parameterizer.ParameterizerConfigT{
+			Helm:        "helm",
 			Kustomize:   "kustomize",
 			OCTemplates: "octemplates",
-			ProjectName: projectName}
+			ProjectName: projectName,
+		}
 		if len(t.ParameterizerConfig.HelmPath) == 0 {
 			pt.Helm = ""
 		}
@@ -142,7 +144,7 @@ func (t *Parameterizer) Transform(newArtifacts []transformertypes.Artifact, alre
 		}
 		filesWritten, err := parameterizer.Parameterize(yamlsPath, destPath, pt, t.parameterizers)
 		if err != nil {
-			logrus.Errorf("Unable to parameterize: %s", err)
+			logrus.Errorf("failed to parameterize the YAML files in the source directory %s and write to output directory %s . Error: %q", yamlsPath, destPath, err)
 			continue
 		}
 		logrus.Debugf("Number of files written by parameterizer: %d", len(filesWritten))

--- a/transformer/transformer.go
+++ b/transformer/transformer.go
@@ -405,8 +405,8 @@ func transform(newArtifactsToProcess, allArtifacts []transformertypes.Artifact, 
 	if pt == dependency && (depSel == nil || depSel.String() == "") {
 		return nil, nil, newArtifactsToProcess
 	}
-	for _, t := range transformers {
-		tconfig, env := t.GetConfig()
+	for _, transformer := range transformers {
+		tconfig, env := transformer.GetConfig()
 		if pt == dependency && !depSel.Matches(labels.Set(tconfig.Labels)) {
 			continue
 		}
@@ -423,7 +423,7 @@ func transform(newArtifactsToProcess, allArtifacts []transformertypes.Artifact, 
 		if len(artifactsToNotConsume) != 0 {
 			logrus.Errorf("Artifacts to not consume : %d. This should have been 0.", len(artifactsToNotConsume))
 		}
-		producedNewPathMappings, producedNewArtifacts, err := runSingleTransform(artifactsToConsume, allArtifacts, t, tconfig, env)
+		producedNewPathMappings, producedNewArtifacts, err := runSingleTransform(artifactsToConsume, allArtifacts, transformer, tconfig, env)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
In docker compose YAML file it is not necessary to have a volume name
https://docs.docker.com/compose/compose-file/compose-file-v3/#short-syntax-3

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>