### PR TITLE
feat: Add support for ibmcloud cf cli to move2kube collect

### DIFF
--- a/collector/cfappscollector.go
+++ b/collector/cfappscollector.go
@@ -38,14 +38,66 @@ func (c *CfAppsCollector) GetAnnotations() []string {
 	return annotations
 }
 
+// getNewIbmcloudCfClient returns a new ibmcloud cf client
+func (c *CfAppsCollector) getNewIbmcloudCfClient(homeDir string) (*cfclient.Client, error) {
+	var client *cfclient.Client
+	cfclientConfig, err := cfclient.NewConfigFromCFHome(filepath.Join(homeDir, ".ibmcloud/"))
+	if err == nil {
+		client, err = cfclient.NewClient(cfclientConfig)
+		if err != nil {
+			logrus.Debugf("The .ibmcloud directory based cf login failed while creating new client. Falling back to the .bluemix directory based login")
+			cfclientConfig, err = cfclient.NewConfigFromCFHome(filepath.Join(homeDir, ".bluemix/"))
+			if err == nil {
+				client, err = cfclient.NewClient(cfclientConfig)
+				if err != nil {
+					logrus.Debugf("The .bluemix directory based cf login failed while creating new client.")
+				}
+			} else {
+				logrus.Debugf("Unable to get cf config from .bluemix directory : %s", err)
+			}
+		}
+	} else {
+		logrus.Debugf("Unable to get cf config from .ibmcloud directory : %s", err)
+		logrus.Debugf("The .ibmcloud directory based cf login failed. Falling back to the .bluemix directory based login")
+		cfclientConfig, err = cfclient.NewConfigFromCFHome(filepath.Join(homeDir, ".bluemix/"))
+		if err == nil {
+			client, err = cfclient.NewClient(cfclientConfig)
+			if err != nil {
+				logrus.Debugf("The .bluemix directory based cf login failed while creating new client.")
+			}
+		} else {
+			logrus.Debugf("Unable to get cf config from .bluemix directory : %s", err)
+		}
+	}
+	return client, err
+}
+
+// getNewClient returns a new client
+func (c *CfAppsCollector) getNewClient(homeDir string) (*cfclient.Client, error) {
+	var client *cfclient.Client
+	cfclientConfig, err := cfclient.NewConfigFromCF()
+	if err == nil {
+		client, err = cfclient.NewClient(cfclientConfig)
+		if err != nil {
+			logrus.Debugf("The .cf directory based cf login failed while creating new client. Falling back to .ibmcloud directory based login")
+			client, err = c.getNewIbmcloudCfClient(homeDir)
+		}
+	} else {
+		logrus.Debugf("Error while getting cf config : %s", err)
+		logrus.Debugf("The .cf directory based cf login failed. Falling back to the .ibmcloud directory based login")
+		client, err = c.getNewIbmcloudCfClient(homeDir)
+	}
+	return client, err
+}
+
 //Collect gets the cf app metadata by querying the cf app. Assumes that the authentication with cluster is already done.
 func (c *CfAppsCollector) Collect(inputPath string, outputPath string) error {
-	cli, err := cfclient.NewConfigFromCF()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		logrus.Errorf("Error while getting cf config : %s", err)
+		logrus.Errorf("Error while getting current user's home directory: %s", err)
 		return err
 	}
-	client, err := cfclient.NewClient(cli)
+	client, err := c.getNewClient(homeDir)
 	if err != nil {
 		logrus.Errorf("Unable to connect to cf client : %s", err)
 		return err

--- a/collector/cfappscollector.go
+++ b/collector/cfappscollector.go
@@ -39,12 +39,7 @@ func (c *CfAppsCollector) GetAnnotations() []string {
 
 //Collect gets the cf app metadata by querying the cf app. Assumes that the authentication with cluster is already done.
 func (c *CfAppsCollector) Collect(inputPath string, outputPath string) error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		logrus.Errorf("Error while getting current user's home directory: %s", err)
-		return err
-	}
-	client, err := getCfClient(homeDir)
+	client, err := getCfClient()
 	if err != nil {
 		logrus.Errorf("Unable to connect to cf client : %s", err)
 		return err

--- a/collector/cfservicescollector.go
+++ b/collector/cfservicescollector.go
@@ -39,12 +39,7 @@ func (c *CfServicesCollector) GetAnnotations() []string {
 
 //Collect gets the cf service metadata by querying the cf app. Assumes that the authentication with cluster is already done.
 func (c *CfServicesCollector) Collect(inputPath string, outputPath string) error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		logrus.Errorf("Error while getting current user's home directory: %s", err)
-		return err
-	}
-	client, err := getCfClient(homeDir)
+	client, err := getCfClient()
 	if err != nil {
 		logrus.Errorf("Unable to connect to cf client : %s", err)
 		return err

--- a/collector/cfservicescollector.go
+++ b/collector/cfservicescollector.go
@@ -24,7 +24,6 @@ import (
 	"github.com/konveyor/move2kube/common"
 	collecttypes "github.com/konveyor/move2kube/types/collection"
 
-	cfclient "github.com/cloudfoundry-community/go-cfclient"
 	"github.com/sirupsen/logrus"
 )
 
@@ -38,58 +37,6 @@ func (c *CfServicesCollector) GetAnnotations() []string {
 	return annotations
 }
 
-// getNewIbmcloudCfClient returns a new ibmcloud cf client
-func (c *CfServicesCollector) getNewIbmcloudCfClient(homeDir string) (*cfclient.Client, error) {
-	var client *cfclient.Client
-	cfclientConfig, err := cfclient.NewConfigFromCFHome(filepath.Join(homeDir, ".ibmcloud/"))
-	if err == nil {
-		client, err = cfclient.NewClient(cfclientConfig)
-		if err != nil {
-			logrus.Debugf("The .ibmcloud directory based cf login failed while creating new client. Falling back to the .bluemix directory based login")
-			cfclientConfig, err = cfclient.NewConfigFromCFHome(filepath.Join(homeDir, ".bluemix/"))
-			if err == nil {
-				client, err = cfclient.NewClient(cfclientConfig)
-				if err != nil {
-					logrus.Debugf("The .bluemix directory based cf login failed while creating new client.")
-				}
-			} else {
-				logrus.Debugf("Unable to get cf config from .bluemix directory : %s", err)
-			}
-		}
-	} else {
-		logrus.Debugf("Unable to get cf config from .ibmcloud directory : %s", err)
-		logrus.Debugf("The .ibmcloud directory based cf login failed. Falling back to the .bluemix directory based login")
-		cfclientConfig, err = cfclient.NewConfigFromCFHome(filepath.Join(homeDir, ".bluemix/"))
-		if err == nil {
-			client, err = cfclient.NewClient(cfclientConfig)
-			if err != nil {
-				logrus.Debugf("The .bluemix directory based cf login failed while creating new client.")
-			}
-		} else {
-			logrus.Debugf("Unable to get cf config from .bluemix directory : %s", err)
-		}
-	}
-	return client, err
-}
-
-// getNewClient returns a new client
-func (c *CfServicesCollector) getNewClient(homeDir string) (*cfclient.Client, error) {
-	var client *cfclient.Client
-	cfclientConfig, err := cfclient.NewConfigFromCF()
-	if err == nil {
-		client, err = cfclient.NewClient(cfclientConfig)
-		if err != nil {
-			logrus.Debugf("The .cf directory based cf login failed while creating new client. Falling back to .ibmcloud directory based login")
-			client, err = c.getNewIbmcloudCfClient(homeDir)
-		}
-	} else {
-		logrus.Debugf("Error while getting cf config : %s", err)
-		logrus.Debugf("The .cf directory based cf login failed. Falling back to the .ibmcloud directory based login")
-		client, err = c.getNewIbmcloudCfClient(homeDir)
-	}
-	return client, err
-}
-
 //Collect gets the cf service metadata by querying the cf app. Assumes that the authentication with cluster is already done.
 func (c *CfServicesCollector) Collect(inputPath string, outputPath string) error {
 	homeDir, err := os.UserHomeDir()
@@ -97,7 +44,7 @@ func (c *CfServicesCollector) Collect(inputPath string, outputPath string) error
 		logrus.Errorf("Error while getting current user's home directory: %s", err)
 		return err
 	}
-	client, err := c.getNewClient(homeDir)
+	client, err := getCfClient(homeDir)
 	if err != nil {
 		logrus.Errorf("Unable to connect to cf client : %s", err)
 		return err

--- a/collector/cfservicescollector.go
+++ b/collector/cfservicescollector.go
@@ -38,14 +38,66 @@ func (c *CfServicesCollector) GetAnnotations() []string {
 	return annotations
 }
 
+// getNewIbmcloudCfClient returns a new ibmcloud cf client
+func (c *CfServicesCollector) getNewIbmcloudCfClient(homeDir string) (*cfclient.Client, error) {
+	var client *cfclient.Client
+	cfclientConfig, err := cfclient.NewConfigFromCFHome(filepath.Join(homeDir, ".ibmcloud/"))
+	if err == nil {
+		client, err = cfclient.NewClient(cfclientConfig)
+		if err != nil {
+			logrus.Debugf("The .ibmcloud directory based cf login failed while creating new client. Falling back to the .bluemix directory based login")
+			cfclientConfig, err = cfclient.NewConfigFromCFHome(filepath.Join(homeDir, ".bluemix/"))
+			if err == nil {
+				client, err = cfclient.NewClient(cfclientConfig)
+				if err != nil {
+					logrus.Debugf("The .bluemix directory based cf login failed while creating new client.")
+				}
+			} else {
+				logrus.Debugf("Unable to get cf config from .bluemix directory : %s", err)
+			}
+		}
+	} else {
+		logrus.Debugf("Unable to get cf config from .ibmcloud directory : %s", err)
+		logrus.Debugf("The .ibmcloud directory based cf login failed. Falling back to the .bluemix directory based login")
+		cfclientConfig, err = cfclient.NewConfigFromCFHome(filepath.Join(homeDir, ".bluemix/"))
+		if err == nil {
+			client, err = cfclient.NewClient(cfclientConfig)
+			if err != nil {
+				logrus.Debugf("The .bluemix directory based cf login failed while creating new client.")
+			}
+		} else {
+			logrus.Debugf("Unable to get cf config from .bluemix directory : %s", err)
+		}
+	}
+	return client, err
+}
+
+// getNewClient returns a new client
+func (c *CfServicesCollector) getNewClient(homeDir string) (*cfclient.Client, error) {
+	var client *cfclient.Client
+	cfclientConfig, err := cfclient.NewConfigFromCF()
+	if err == nil {
+		client, err = cfclient.NewClient(cfclientConfig)
+		if err != nil {
+			logrus.Debugf("The .cf directory based cf login failed while creating new client. Falling back to .ibmcloud directory based login")
+			client, err = c.getNewIbmcloudCfClient(homeDir)
+		}
+	} else {
+		logrus.Debugf("Error while getting cf config : %s", err)
+		logrus.Debugf("The .cf directory based cf login failed. Falling back to the .ibmcloud directory based login")
+		client, err = c.getNewIbmcloudCfClient(homeDir)
+	}
+	return client, err
+}
+
 //Collect gets the cf service metadata by querying the cf app. Assumes that the authentication with cluster is already done.
 func (c *CfServicesCollector) Collect(inputPath string, outputPath string) error {
-	cli, err := cfclient.NewConfigFromCF()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		logrus.Errorf("Error while getting cf config : %s", err)
+		logrus.Errorf("Error while getting current user's home directory: %s", err)
 		return err
 	}
-	client, err := cfclient.NewClient(cli)
+	client, err := c.getNewClient(homeDir)
 	if err != nil {
 		logrus.Errorf("Unable to connect to cf client : %s", err)
 		return err

--- a/collector/cfutils.go
+++ b/collector/cfutils.go
@@ -1,0 +1,54 @@
+/*
+ *  Copyright IBM Corporation 2021
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package collector
+
+import (
+	"path/filepath"
+
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	"github.com/sirupsen/logrus"
+)
+
+// getCfClient returns a new cf client
+func getCfClient(homeDir string) (*cfclient.Client, error) {
+	var client *cfclient.Client
+	var err error
+	var cfClientConfig *cfclient.Config
+	cfHomeDirs := [3]string{"", ".ibmcloud", ".bluemix"}
+	for _, cfHomeDir := range cfHomeDirs {
+		cfClientConfig, err = cfclient.NewConfigFromCFHome(filepath.Join(homeDir, cfHomeDir))
+		if err != nil {
+			if cfHomeDir == "" {
+				logrus.Debugf("The .cf directory based cf login failed. Unable to get cf config : %s", err)
+			} else {
+				logrus.Debugf("The %s directory based cf login failed. Unable to get cf config : %s", cfHomeDir, err)
+			}
+		} else {
+			client, err = cfclient.NewClient(cfClientConfig)
+			if err != nil {
+				if cfHomeDir == "" {
+					logrus.Debugf("The .cf directory based cf login failed while creating new client.")
+				} else {
+					logrus.Debugf("The %s directory based cf login failed while creating new client.", cfHomeDir)
+				}
+			} else {
+				break
+			}
+		}
+	}
+	return client, err
+}


### PR DESCRIPTION
With `ibmcloud login`

```console
➜  move2kube git:(ibmcloud-cf-collect) move2kube collect -a cf        
INFO[0000] Begin collection                             
INFO[0000] [*collector.CfAppsCollector] Begin collection 
INFO[0015] Changing metadata name from IBM Cloud to ibm-cloud 
INFO[0019] [*collector.CfAppsCollector] Done            
INFO[0019] [*collector.CfServicesCollector] Begin collection 
INFO[0039] Changing metadata name from IBM Cloud to ibm-cloud 
INFO[0039] [*collector.CfServicesCollector] Done        
INFO[0039] Collection done                              
INFO[0039] Collect Output in [/Users/akash/github/move2kube/m2k_collect]. Copy this directory into the source directory to be used for planning.
```

When login is through `ibmcloud login` and not `cf login` with debug log-level

```console
➜  move2kube git:(ibmcloud-cf-collect) ✗ move2kube collect -a cf --log-level debug
INFO[0000] Begin collection                             
INFO[0000] [*collector.CfAppsCollector] Begin collection 
DEBU[0002] Default cf cli login failed while creating new client. Falling back to .ibmcloud dir based login 
DEBU[0002] Unable to get cf config from .ibmcloud dir : open /Users/akash/.ibmcloud/.cf/config.json: no such file or directory 
DEBU[0002] The .ibmcloud dir based cf login failed. Falling back to the .bluemix dir based login 
INFO[0012] Changing metadata name from IBM Cloud to ibm-cloud 
INFO[0018] [*collector.CfAppsCollector] Done            
INFO[0018] [*collector.CfServicesCollector] Begin collection 
DEBU[0019] Default cf cli login failed while creating new client. Falling back to .ibmcloud dir based login 
DEBU[0019] Unable to get cf config from .ibmcloud dir : open /Users/akash/.ibmcloud/.cf/config.json: no such file or directory 
DEBU[0019] The .ibmcloud dir based cf login failed. Falling back to the .bluemix dir based login 
INFO[0028] Changing metadata name from IBM Cloud to ibm-cloud 
INFO[0028] [*collector.CfServicesCollector] Done        
INFO[0028] Collection done                              
INFO[0028] Collect Output in [/Users/akash/github/move2kube/m2k_collect]. Copy this directory into the source directory to be used for planning.
```

When `cf` cli is not installed, and thus there is no `.cf` folder

```console
➜  move2kube git:(ibmcloud-cf-collect) ✗ move2kube collect -a cf --log-level debug
INFO[0000] Begin collection                             
INFO[0000] [*collector.CfAppsCollector] Begin collection 
DEBU[0000] Error while getting cf config : open /Users/akash/.cf/config.json: no such file or directory 
DEBU[0000] Default cf cli login failed. Falling back to the .ibmcloud directory based login 
DEBU[0000] Unable to get cf config from .ibmcloud directory : open /Users/akash/.ibmcloud/.cf/config.json: no such file or directory 
DEBU[0000] The .ibmcloud directory based cf login failed. Falling back to the .bluemix directory based login 
INFO[0025] Changing metadata name from IBM Cloud to ibm-cloud 
INFO[0030] [*collector.CfAppsCollector] Done            
INFO[0030] [*collector.CfServicesCollector] Begin collection 
DEBU[0030] Error while getting cf config : open /Users/akash/.cf/config.json: no such file or directory 
DEBU[0030] Default cf cli login failed. Falling back to the .ibmcloud directory based login 
DEBU[0030] Unable to get cf config from .ibmcloud directory : open /Users/akash/.ibmcloud/.cf/config.json: no such file or directory 
DEBU[0030] The .ibmcloud directory based cf login failed. Falling back to the .bluemix directory based login 
INFO[0060] Changing metadata name from IBM Cloud to ibm-cloud 
INFO[0060] [*collector.CfServicesCollector] Done        
INFO[0060] Collection done                              
INFO[0060] Collect Output in [/Users/akash/github/move2kube/m2k_collect]. Copy this directory into the source directory to be used for planning.
```

With `cf login` 

```console
➜  move2kube git:(ibmcloud-cf-collect) move2kube collect -a cf --log-level debug
INFO[0000] Begin collection                             
INFO[0000] [*collector.CfAppsCollector] Begin collection 
INFO[0015] Changing metadata name from IBM Cloud to ibm-cloud 
INFO[0020] [*collector.CfAppsCollector] Done            
INFO[0020] [*collector.CfServicesCollector] Begin collection 
INFO[0059] Changing metadata name from IBM Cloud to ibm-cloud 
INFO[0059] [*collector.CfServicesCollector] Done        
INFO[0059] Collection done                              
INFO[0059] Collect Output in [/Users/akash/github/move2kube/m2k_collect]. Copy this directory into the source directory to be used for planning.
```

Co-authored-by: Ashok Pon Kumar <ashokponkumar@gmail.com>
Signed-off-by: Akash Nayak <akash19nayak@gmail.com>