### PR TITLE
fix: Temporary fix for the missing Node.js version in the generated Dockerfile due to package.json file

### DIFF
--- a/assets/built-in/transformers/dockerfilegenerator/nodejs/transformer.yaml
+++ b/assets/built-in/transformers/dockerfilegenerator/nodejs/transformer.yaml
@@ -18,4 +18,4 @@ spec:
     DockerfileForService:
       disabled: false
   config:
-    defaultNodejsVersion: "12"
+    defaultNodejsVersion: "14"

--- a/transformer/dockerfilegenerator/nodejsdockerfiletransformer.go
+++ b/transformer/dockerfilegenerator/nodejsdockerfiletransformer.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	defaultNodeVersion = "12"
+	defaultNodeVersion = "14"
 	packageJSONFile    = "package.json"
 )
 
@@ -146,7 +146,7 @@ func (t *NodejsDockerfileGenerator) Transform(newArtifacts []transformertypes.Ar
 			logrus.Debugf("unable to load config for Transformer into %T : %s", ir, err)
 		}
 		build := false
-		nodeVersion := t.NodejsConfig.DefaultNodejsVersion
+		var nodeVersion string
 		var packageJSON PackageJSON
 		if err := common.ReadJSON(filepath.Join(a.Paths[artifacts.ServiceDirPathType][0], packageJSONFile), &packageJSON); err != nil {
 			logrus.Debugf("unable to read the package.json file: %s", err)
@@ -160,6 +160,9 @@ func (t *NodejsDockerfileGenerator) Transform(newArtifacts []transformertypes.Ar
 				}
 				nodeVersion = strings.TrimPrefix(semver.Major(node), "v")
 			}
+		}
+		if nodeVersion == "" {
+			nodeVersion = t.NodejsConfig.DefaultNodejsVersion
 		}
 		ports := ir.GetAllServicePorts()
 		if len(ports) == 0 {


### PR DESCRIPTION
This PR puts a temporary fix for the missing Node.js version in the generated Dockerfile which happens in case of conditional node version (say, <16.15) in the package.json file.

Signed-off-by: Akash Nayak <akash19nayak@gmail.com>
