### PR TITLE
fix: panic when docker is not installed and CNB containerizer is used

### DIFF
--- a/environment/container/container.go
+++ b/environment/container/container.go
@@ -55,14 +55,11 @@ type ContainerEngine interface {
 func initContainerEngine() (err error) {
 	workingEngine, err = newDockerEngine()
 	if err != nil {
-		logrus.Debugf("Unable to use docker : %s", err)
-		return err
+		return fmt.Errorf("failed to use docker as the container engine. Error: %q", err)
 	}
 	//TODO: Add Support for podman
 	if workingEngine == nil {
-		err := fmt.Errorf("no working container runtime available")
-		logrus.Errorf("%s", err)
-		return err
+		return fmt.Errorf("no working container runtime available")
 	}
 	return nil
 }
@@ -72,7 +69,9 @@ func GetContainerEngine() ContainerEngine {
 	if !inited {
 		disabled = !qaengine.FetchBoolAnswer(common.ConfigSpawnContainersKey, "Allow spawning containers?", []string{"If this setting is set to false, those transformers that rely on containers will not work."}, false)
 		if !disabled {
-			initContainerEngine()
+			if err := initContainerEngine(); err != nil {
+				logrus.Fatalf("failed to initialize the container engine. Error: %q", err)
+			}
 		}
 		inited = true
 	}

--- a/environment/container/dockerengine.go
+++ b/environment/container/dockerengine.go
@@ -48,20 +48,18 @@ func newDockerEngine() (*dockerEngine, error) {
 	ctx := context.Background()
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
-		logrus.Debugf("Unable to create docker client : %s", err)
-		return nil, err
+		return nil, fmt.Errorf("unable to create docker client. Error: %q", err)
 	}
-	e := &dockerEngine{
+	engine := &dockerEngine{
 		availableImages: map[string]bool{},
 		cli:             cli,
 		ctx:             ctx,
 	}
-	_, _, err = e.RunContainer(testimage, environmenttypes.Command{}, "", "")
+	_, _, err = engine.RunContainer(testimage, environmenttypes.Command{}, "", "")
 	if err != nil {
-		logrus.Errorf("Unable to run test container : %s", err)
-		return nil, err
+		return engine, fmt.Errorf("unable to run test image '%s' as a container. Error: %q", testimage, err)
 	}
-	return e, nil
+	return engine, nil
 }
 
 func (e *dockerEngine) pullImage(image string) bool {
@@ -284,18 +282,14 @@ func (e *dockerEngine) RemoveImage(image string) (err error) {
 // RunContainer executes a container
 func (e *dockerEngine) RunContainer(image string, cmd environmenttypes.Command, volsrc string, voldest string) (output string, containerStarted bool, err error) {
 	if !e.pullImage(image) {
-		logrus.Debugf("Unable to pull image using docker : %s", image)
-		return "", false, fmt.Errorf("unable to pull image")
+		return "", false, fmt.Errorf("unable to pull image '%s' using docker", image)
 	}
 	ctx := context.Background()
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
-		logrus.Debugf("Error during docker client creation : %s", err)
-		return "", false, err
+		return "", false, fmt.Errorf("failed to create a docker client. Error: %q", err)
 	}
-	contconfig := &container.Config{
-		Image: image,
-	}
+	contconfig := &container.Config{Image: image}
 	if (volsrc == "" && voldest != "") || (volsrc != "" && voldest == "") {
 		logrus.Warnf("Either volume source (%s) or destination (%s) is empty. Ingoring volume mount.", volsrc, voldest)
 	}
@@ -312,28 +306,25 @@ func (e *dockerEngine) RunContainer(image string, cmd environmenttypes.Command, 
 	}
 	resp, err := cli.ContainerCreate(ctx, contconfig, hostconfig, nil, nil, "")
 	if err != nil {
-		logrus.Debugf("Error during container creation : %s", err)
+		logrus.Debugf("failed to create the container with contconfig %+v and hostconfig %+v . Error: %q", contconfig, hostconfig, err)
 		resp, err = cli.ContainerCreate(ctx, contconfig, nil, nil, nil, "")
 		if err != nil {
-			logrus.Debugf("Container creation failed with image %s with no volumes", image)
-			return "", false, err
+			return "", false, fmt.Errorf("container creation failed for image '%s' with no volumes", image)
 		}
 		logrus.Debugf("Container %s created with image %s with no volumes", resp.ID, image)
 		defer cli.ContainerRemove(ctx, resp.ID, types.ContainerRemoveOptions{Force: true})
 		if volsrc != "" && voldest != "" {
 			err = copyDir(ctx, cli, resp.ID, volsrc, voldest)
 			if err != nil {
-				logrus.Debugf("Container data copy failed for image %s with volume %s:%s : %s", image, volsrc, voldest, err)
-				return "", false, err
+				return "", false, fmt.Errorf("container data copy failed for image '%s' with volume (%s:%s). Error: %q", image, volsrc, voldest, err)
 			}
-			logrus.Debugf("Data copied from %s to %s in container %s with image %s", volsrc, voldest, resp.ID, image)
+			logrus.Debugf("Data copied from (%s) to (%s) in container '%s' with image '%s'", volsrc, voldest, resp.ID, image)
 		}
 	}
 	logrus.Debugf("Container %s created with image %s", resp.ID, image)
 	defer cli.ContainerRemove(ctx, resp.ID, types.ContainerRemoveOptions{Force: true})
 	if err = cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
-		logrus.Debugf("Error during container startup of container %s : %s", resp.ID, err)
-		return "", false, err
+		return "", false, fmt.Errorf("failed to startup the container '%s' . Error: %q", resp.ID, err)
 	}
 	statusCh, errCh := cli.ContainerWait(
 		ctx,

--- a/environment/container/dockerengine_test.go
+++ b/environment/container/dockerengine_test.go
@@ -30,8 +30,8 @@ func TestIsBuilderAvailable(t *testing.T) {
 		image := "quay.io/konveyor/move2kube"
 
 		// Test
-		if !provider.pullImage(image) {
-			t.Fatalf("Failed to find the image %q locally and/or pull it.", image)
+		if err := provider.pullImage(image); err != nil {
+			t.Fatalf("Failed to find the image '%s' locally and/or pull it. Error: %q", image, err)
 		}
 	})
 
@@ -40,22 +40,22 @@ func TestIsBuilderAvailable(t *testing.T) {
 		image := "quay.io/konveyor/move2kube"
 
 		// Test
-		if !provider.pullImage(image) {
-			t.Fatalf("Failed to find the image %q locally and/or pull it.", image)
+		if err := provider.pullImage(image); err != nil {
+			t.Fatalf("Failed to find the image '%s' locally and/or pull it. Error: %q", image, err)
 		}
 		if !provider.availableImages[image] {
 			t.Fatalf("Failed to add the image %q to the list of available images", image)
 		}
-		if !provider.pullImage(image) {
-			t.Fatalf("Failed to find the image %q locally and/or pull it.", image)
+		if err := provider.pullImage(image); err != nil {
+			t.Fatalf("Failed to find the image '%s' locally and/or pull it. Error: %q", image, err)
 		}
 	})
 
 	t.Run("check for a non existent image", func(t *testing.T) {
 		provider, _ := newDockerEngine()
 		image := "this/doesnotexist:foobar"
-		if provider.pullImage(image) {
-			t.Fatalf("Should not have succeeded. The image %q does not exist", image)
+		if err := provider.pullImage(image); err == nil {
+			t.Fatalf("Should not have succeeded. The image '%s' does not exist", image)
 		}
 	})
 }


### PR DESCRIPTION
New output after the fix
```
$ move2kube plan -s src/ --preset enablecontainerizedtransformers
INFO[0000] Pulling container image quay.io/konveyor/hello-world. This could take a few mins. 
FATA[0000] failed to initialize the container engine. Error: "failed to use docker as the container engine. Error: \"unable to run test image 'quay.io/konveyor/hello-world' as a container. Error: \\\"failed to pull the image 'quay.io/konveyor/hello-world'. Error: \\\\\\\"failed to pull the image 'quay.io/konveyor/hello-world' using the docker client. Error: \\\\\\\\\\\\\\\"Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?\\\\\\\\\\\\\\\"\\\\\\\"\\\"\""
```
We exit with error since no container engine is found.

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>