### PR TITLE
fix: inform the user when there are multiple transformation options for a service

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -802,7 +802,7 @@ func MakeStringK8sServiceNameCompliant(s string) string {
 		logrus.Errorf("empty string given to create k8s service name")
 		return s
 	}
-	if !regexp.MustCompile(`^[a-z]`).MatchString(s) {
+	if !regexp.MustCompile(`^[a-zA-Z]`).MatchString(s) {
 		logrus.Warnf("the given k8s service name '%s' starts with a non-alphabetic character", s)
 	}
 	return MakeStringDNSLabelNameCompliant(s)

--- a/lib/transformer.go
+++ b/lib/transformer.go
@@ -72,7 +72,7 @@ func Transform(ctx context.Context, plan plantypes.Plan, outputPath string, tran
 			}
 			option.ServiceName = selectedServiceName
 			selectedTransformationOptions = append(selectedTransformationOptions, option)
-			logrus.Infof("Using the transformer option '%s' for the service '%s'.", option.TransformerName, selectedServiceName)
+			logrus.Infof("Using the transformation option '%s' for the service '%s'.", option.TransformerName, selectedServiceName)
 			found = true
 			break
 		}


### PR DESCRIPTION
The old behaviour simply selects the first valid transformation option without
informing the user. It also used to ignore any service which doesn't have valid
transformation options with just a debug message.

New behaviour:
```
? Select all services that are needed:
ID: move2kube.services.[].enable
Hints:
- The services unselected here will be ignored.

 eShop
INFO[0000] Found multiple transformation options for the service 'eShop'. Selecting the first valid option. 
INFO[0000] Using the transformation option 'WinConsoleApp-Dockerfile' for the service 'eShop'.
```

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>