### PR TITLE
fix: difference between how multi-select questions were read and written to config was causing unnecessary questions to be asked

### DIFF
--- a/transformer/dockerfilegenerator/java/waranalyser.go
+++ b/transformer/dockerfilegenerator/java/waranalyser.go
@@ -80,11 +80,10 @@ func (t *WarAnalyser) DirectoryDetect(dir string) (map[string][]transformertypes
 		return nil, nil
 	}
 	for _, path := range paths {
-		rawServiceName := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
-		serviceName := common.MakeStringK8sServiceNameCompliant(rawServiceName)
-		imageName := common.MakeStringContainerImageNameCompliant(rawServiceName)
+		serviceName := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		normalizedServiceName := common.MakeStringK8sServiceNameCompliant(serviceName)
+		imageName := common.MakeStringContainerImageNameCompliant(serviceName)
 		newArtifact := transformertypes.Artifact{
-			Type: artifacts.ServiceArtifactType,
 			Paths: map[transformertypes.PathType][]string{
 				artifacts.WarPathType:        {path},
 				artifacts.ServiceDirPathType: {dir},
@@ -94,11 +93,10 @@ func (t *WarAnalyser) DirectoryDetect(dir string) (map[string][]transformertypes
 					DeploymentFilePath: filepath.Base(path),
 					JavaVersion:        t.WarConfig.JavaVersion,
 				},
-				artifacts.ServiceConfigType:   artifacts.ServiceConfig{ServiceName: serviceName},
 				artifacts.ImageNameConfigType: artifacts.ImageName{ImageName: imageName},
 			},
 		}
-		services[serviceName] = append(services[serviceName], newArtifact)
+		services[normalizedServiceName] = append(services[normalizedServiceName], newArtifact)
 	}
 	return services, nil
 }

--- a/transformer/dockerfilegenerator/java/zuulanalyser.go
+++ b/transformer/dockerfilegenerator/java/zuulanalyser.go
@@ -79,10 +79,9 @@ func (t *ZuulAnalyser) DirectoryDetect(dir string) (services map[string][]transf
 func (t *ZuulAnalyser) Transform(newArtifacts []transformertypes.Artifact, alreadySeenArtifacts []transformertypes.Artifact) ([]transformertypes.PathMapping, []transformertypes.Artifact, error) {
 	artifactsCreated := []transformertypes.Artifact{}
 	for _, a := range newArtifacts {
-		var ir irtypes.IR
-		err := a.GetConfig(irtypes.IRConfigType, &ir)
-		if err != nil {
-			logrus.Errorf("unable to load config for Transformer into %T : %s", ir, err)
+		ir := irtypes.IR{}
+		if err := a.GetConfig(irtypes.IRConfigType, &ir); err != nil {
+			logrus.Errorf("unable to load config for Transformer into %T Error: %q", ir, err)
 			continue
 		}
 		for sn, s := range ir.Services {

--- a/types/qaengine/config.go
+++ b/types/qaengine/config.go
@@ -137,7 +137,7 @@ func (c *Config) specialGetSolution(p Problem) (Problem, error) {
 	// We take the mere existence of 'a.b.c.d' to indicate that the user wants to skip the question.
 	atleastOneKeyHasLastSegment := false
 	for k := range baseValueMap {
-		newK := baseKey + common.Delim + k + common.Delim + lastKeySegment
+		newK := baseKey + common.Delim + `"` + k + `"` + common.Delim + lastKeySegment
 		lastKeySegmentValue, ok := c.Get(newK)
 		if !ok {
 			continue
@@ -156,7 +156,7 @@ func (c *Config) specialGetSolution(p Problem) (Problem, error) {
 	selectedOptions := []string{}
 	for _, option := range p.Options {
 		isOptionSelected := true
-		newKey := baseKey + common.Delim + option + common.Delim + lastKeySegment
+		newKey := baseKey + common.Delim + `"` + option + `"` + common.Delim + lastKeySegment
 		if newValue, ok := c.Get(newKey); ok {
 			isOptionSelected, ok = newValue.(bool)
 			if !ok {

--- a/types/transformer/artifacts/artifacts.go
+++ b/types/transformer/artifacts/artifacts.go
@@ -20,9 +20,16 @@ import (
 	transformertypes "github.com/konveyor/move2kube/types/transformer"
 )
 
+// OriginalNameConfig stores the original name of the app
+type OriginalNameConfig struct {
+	OriginalName string `yaml:"originalName,omitempty" json:"originalName,omitempty"`
+}
+
 const (
 	// ServiceDirPathType points to the service context directory.
 	ServiceDirPathType transformertypes.PathType = "ServiceDirectories"
 	// ServiceRootDirPathType points to the directory of the root project for a service.
 	ServiceRootDirPathType transformertypes.PathType = "ServiceRootDirectory"
+	// OriginalNameConfigType stores the original name of the app
+	OriginalNameConfigType transformertypes.ConfigType = "OriginalName"
 )

--- a/types/transformer/artifacts/dotnet.go
+++ b/types/transformer/artifacts/dotnet.go
@@ -32,6 +32,8 @@ type DotNetConfig struct {
 type DotNetChildProject struct {
 	// Name is the name of the child project
 	Name string `yaml:"name" json:"name"`
+	// OriginalName is the name of the child project before normalization
+	OriginalName string `yaml:"originalName" json:"originalName"`
 	// RelCSProjPath is the path to the child .csproj (relative to the parent .sln file)
 	RelCSProjPath string `yaml:"csProjPath" json:"csProjPath"`
 	// TargetFramework contains the target dot net core or dot net framework name and version


### PR DESCRIPTION
Also normalize the app name and child project names to avoid inconsistencies
in the names given to the same service by different transformers.

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>