### PR TITLE
fix: the rust transformer was not detecting the rust service in language-platforms

### DIFF
--- a/transformer/dockerfilegenerator/pythondockerfiletransformer.go
+++ b/transformer/dockerfilegenerator/pythondockerfiletransformer.go
@@ -19,7 +19,6 @@ package dockerfilegenerator
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -112,7 +111,7 @@ func findMainScripts(pythonFilesPath []string) ([]string, error) {
 
 // findDjangoDependency checks for django dependency in the requirements.txt file
 func findDjangoDependency(reqTxtFilePath string) bool {
-	reqTxtFile, err := ioutil.ReadFile(reqTxtFilePath)
+	reqTxtFile, err := os.ReadFile(reqTxtFilePath)
 	if err != nil {
 		logrus.Warnf("failed to read the file at path %s . Error: %q", reqTxtFilePath, err)
 		return false

--- a/transformer/dockerfilegenerator/rustdockerfiletransformer.go
+++ b/transformer/dockerfilegenerator/rustdockerfiletransformer.go
@@ -55,7 +55,7 @@ type CargoTomlConfig struct {
 	Package PackageInfo
 }
 
-//PackageInfo implements package properties
+// PackageInfo implements package properties
 type PackageInfo struct {
 	Name    string
 	Version string
@@ -66,7 +66,7 @@ type RocketTomlConfig struct {
 	Global GlobalParameters
 }
 
-//GlobalParameters implements global properties in Rocket.toml
+// GlobalParameters implements global properties in Rocket.toml
 type GlobalParameters struct {
 	Address string
 	Port    int32
@@ -87,7 +87,7 @@ func (t *RustDockerfileGenerator) GetConfig() (transformertypes.Transformer, *en
 // DirectoryDetect runs detect in each sub directory
 func (t *RustDockerfileGenerator) DirectoryDetect(dir string) (map[string][]transformertypes.Artifact, error) {
 	cargoPath := filepath.Join(dir, cargoTomlFile)
-	if _, err := os.Stat(filepath.Join(dir, cargoPath)); err != nil {
+	if _, err := os.Stat(cargoPath); err != nil {
 		return nil, nil
 	}
 	cargoTomlConfig := CargoTomlConfig{}

--- a/transformer/kubernetes/k8sschema/utils.go
+++ b/transformer/kubernetes/k8sschema/utils.go
@@ -19,16 +19,14 @@ package k8sschema
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/konveyor/move2kube/common"
 	"github.com/konveyor/move2kube/types"
-	"gopkg.in/yaml.v3"
-
-	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
@@ -172,7 +170,7 @@ func GetKubernetesObjsInDir(dir string) []runtime.Object {
 		return nil
 	}
 	for _, filePath := range filePaths {
-		data, err := ioutil.ReadFile(filePath)
+		data, err := os.ReadFile(filePath)
 		if err != nil {
 			logrus.Debugf("Failed to read the yaml file at path %q Error: %q", filePath, err)
 			continue


### PR DESCRIPTION
chore: `io/ioutil` package was deprecated, functionality split into the `os` and `io` packages

See https://github.com/go-critic/go-critic/issues/1019

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>