### PR TITLE
fix: bug where the .dll filename was normalized when it shouldn't be in the Dockerfiles generated for Dot Net Core

### DIFF
--- a/transformer/dockerfilegenerator/dotnetcoredockerfilegenerator.go
+++ b/transformer/dockerfilegenerator/dotnetcoredockerfilegenerator.go
@@ -474,7 +474,7 @@ func (t *DotNetCoreDockerfileGenerator) TransformArtifact(newArtifact transforme
 			IncludeBuildStage:     selectedBuildOption == dotnetutils.BUILD_IN_EVERY_IMAGE,
 			BuildStageImageTag:    defaultDotNetCoreVersion,
 			BuildContainerName:    imageToCopyFrom,
-			EntryPointPath:        childProject.Name + ".dll",
+			EntryPointPath:        childProject.OriginalName + ".dll",
 			RunStageImageTag:      targetFrameworkVersion,
 			IncludeRunStage:       true,
 			CopyFrom:              common.GetUnixPath(copyFrom),

--- a/transformer/dockerfilegenerator/windows/consoleappdockerfilegenerator.go
+++ b/transformer/dockerfilegenerator/windows/consoleappdockerfilegenerator.go
@@ -200,7 +200,7 @@ func (t *WinConsoleAppDockerfileGenerator) DirectoryDetect(dir string) (map[stri
 			continue
 		}
 		targetFrameworkVersion := configuration.PropertyGroups[idx].TargetFrameworkVersion
-		if !dotnet.Version4.MatchString(targetFrameworkVersion) {
+		if !dotnet.Version4And3_5.MatchString(targetFrameworkVersion) {
 			logrus.Errorf("console dot net tranformer: the c sharp project file at path %s does not have a supported framework version. Actual version: %s", csProjPath, targetFrameworkVersion)
 			continue
 		}

--- a/transformer/dockerfilegenerator/windows/silverlightwebappdockerfilegenerator.go
+++ b/transformer/dockerfilegenerator/windows/silverlightwebappdockerfilegenerator.go
@@ -104,7 +104,7 @@ func (t *WinSilverLightWebAppDockerfileGenerator) DirectoryDetect(dir string) (m
 			continue
 		}
 		targetFrameworkVersion := configuration.PropertyGroups[idx].TargetFrameworkVersion
-		if !dotnet.Version4.MatchString(targetFrameworkVersion) {
+		if !dotnet.Version4And3_5.MatchString(targetFrameworkVersion) {
 			logrus.Errorf("silverlight dot net tranformer: the c sharp project file at path %s does not have a supported framework version. Actual version: %s", csProjPath, targetFrameworkVersion)
 			continue
 		}

--- a/transformer/dockerfilegenerator/windows/webappdockerfilegenerator.go
+++ b/transformer/dockerfilegenerator/windows/webappdockerfilegenerator.go
@@ -113,7 +113,7 @@ func (t *WinWebAppDockerfileGenerator) DirectoryDetect(dir string) (map[string][
 				continue
 			}
 			targetFrameworkVersion := configuration.PropertyGroups[idx].TargetFrameworkVersion
-			if !dotnet.Version4.MatchString(targetFrameworkVersion) {
+			if !dotnet.Version4And3_5.MatchString(targetFrameworkVersion) {
 				logrus.Errorf("the c sharp project file at path %s does not have a supported framework version. Actual version: %s", csProjPath, targetFrameworkVersion)
 				continue
 			}
@@ -175,7 +175,7 @@ func (t *WinWebAppDockerfileGenerator) DirectoryDetect(dir string) (map[string][
 			continue
 		}
 		targetFrameworkVersion := configuration.PropertyGroups[idx].TargetFrameworkVersion
-		if !dotnet.Version4.MatchString(targetFrameworkVersion) {
+		if !dotnet.Version4And3_5.MatchString(targetFrameworkVersion) {
 			logrus.Errorf("webapp dot net tranformer: the c sharp project file at path %s does not have a supported framework version. Actual version: %s", csProjPath, targetFrameworkVersion)
 			continue
 		}
@@ -306,7 +306,7 @@ func (t *WinWebAppDockerfileGenerator) Transform(newArtifacts []transformertypes
 
 		if selectedBuildOption == dotnetutils.BUILD_IN_BASE_IMAGE {
 			webConfig := WebTemplateConfig{
-				BuildStageImageTag: dotnet.DefaultBaseImageVersion,
+				BuildStageImageTag: t.getImageTagFromVersion(dotnet.DefaultBaseImageVersion),
 				IncludeBuildStage:  true,
 				IncludeRunStage:    false,
 				BuildContainerName: imageToCopyFrom,
@@ -378,7 +378,7 @@ func (t *WinWebAppDockerfileGenerator) Transform(newArtifacts []transformertypes
 
 			webConfig := WebTemplateConfig{
 				Ports:              selectedPorts,
-				BuildStageImageTag: dotnet.DefaultBaseImageVersion,
+				BuildStageImageTag: t.getImageTagFromVersion(targetFrameworkVersion),
 				IncludeBuildStage:  selectedBuildOption == dotnetutils.BUILD_IN_EVERY_IMAGE,
 				IncludeRunStage:    true,
 				BuildContainerName: imageToCopyFrom,

--- a/types/source/dotnet/csproj.go
+++ b/types/source/dotnet/csproj.go
@@ -23,8 +23,8 @@ import (
 )
 
 var (
-	// Version4 is the framework version pattern
-	Version4 = regexp.MustCompile("v4")
+	// Version4And3_5 is the regex to match against specific Dot Net framework versions
+	Version4And3_5 = regexp.MustCompile(`(v4|v3\.5)`)
 	// WebLib is the key library used in web applications
 	WebLib = regexp.MustCompile(`^System\.Web`)
 	// AspNetWebLib is the key library used in asp net web applications


### PR DESCRIPTION
Also add support for Dot Net Framework version 3.5

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>