### PR TITLE
feat: Support installing Move2Kube using the installation script on Power, s390x and arm64 systems

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -141,7 +141,7 @@ initOS() {
 # verifySupported checks that the os/arch combination is supported for
 # binary builds, as well whether or not necessary tools are present.
 verifySupported() {
-    local supported='darwin-amd64\nlinux-amd64\nlinux-ppc64le\nlinux-s390x'
+    local supported='darwin-amd64\nlinux-amd64\nlinux-ppc64le\nlinux-s390x\ndarwin-arm64'
     if ! echo "$supported" | grep -q "${OS}-${ARCH}"; then
         echo "No prebuilt binary for ${OS}-${ARCH}."
         echo "To build from source, go to https://github.com/konveyor/move2kube"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -141,7 +141,7 @@ initOS() {
 # verifySupported checks that the os/arch combination is supported for
 # binary builds, as well whether or not necessary tools are present.
 verifySupported() {
-    local supported='darwin-amd64\nlinux-amd64'
+    local supported='darwin-amd64\nlinux-amd64\nlinux-ppc64le\nlinux-s390x'
     if ! echo "$supported" | grep -q "${OS}-${ARCH}"; then
         echo "No prebuilt binary for ${OS}-${ARCH}."
         echo "To build from source, go to https://github.com/konveyor/move2kube"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -141,7 +141,7 @@ initOS() {
 # verifySupported checks that the os/arch combination is supported for
 # binary builds, as well whether or not necessary tools are present.
 verifySupported() {
-    local supported='darwin-amd64\nlinux-amd64\nlinux-ppc64le\nlinux-s390x\ndarwin-arm64'
+    local supported='darwin-amd64\nlinux-amd64\nlinux-ppc64le\nlinux-s390x\ndarwin-arm64\nlinux-arm64'
     if ! echo "$supported" | grep -q "${OS}-${ARCH}"; then
         echo "No prebuilt binary for ${OS}-${ARCH}."
         echo "To build from source, go to https://github.com/konveyor/move2kube"


### PR DESCRIPTION
I have tested the Move2Kube installation on the ppc64le Power VM after making the changes to the `install.sh` script locally.

```console
[root@test-lab-vm ~]# MOVE2KUBE_TAG='v0.4.0-alpha.0' bash <install.sh
Installing move2kube
Downloading https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
Downloading https://github.com/konveyor/move2kube/releases/download/v0.4.0-alpha.0/move2kube-v0.4.0-alpha.0-linux-ppc64le.tar.gz
Downloading https://github.com/konveyor/move2kube/releases/download/v0.4.0-alpha.0/move2kube-v0.4.0-alpha.0-linux-ppc64le.tar.gz.sha256sum
Verifying checksum
Preparing to install move2kube into the directory: /usr/local/bin
If it fails, you can retry with a different installation directory. Example: MOVE2KUBE_INSTALL_DIR=/my/new/install/dir
Successfully installed move2kube into /usr/local/bin/move2kube
Done!
cleaning up temporary files and directories...

[root@test-lab-vm ~]# move2kube version -l
version: v0.4.0-alpha.0
gitCommit: e58c21caabcd2cdb7dd0f7f0fcc1e6afc8a35986
gitTreeState: clean
goVersion: go1.18.6
platform: linux/ppc64le
```

Signed-off-by: Akash Nayak <akash19nayak@gmail.com>