### PR TITLE
fix: when the user specifies a replicas other than 2 it is not properly reflected in the Helm chart values.yaml

### DIFF
--- a/assets/built-in/transformers/kubernetes/parameterizer/parameterizers/replicas.yaml
+++ b/assets/built-in/transformers/kubernetes/parameterizer/parameterizers/replicas.yaml
@@ -6,6 +6,7 @@ spec:
   parameterizers:
     - target: "spec.replicas"
       template: "${common.replicas}"
+      keepOriginalValueIfPresent: true
       default: 2
       filters:
         - kind: Deployment

--- a/transformer/kubernetes/parameterizer/types.go
+++ b/transformer/kubernetes/parameterizer/types.go
@@ -54,13 +54,14 @@ type ParameterizerSpecT struct {
 
 // ParameterizerT is a paramterizer
 type ParameterizerT struct {
-	Target     string            `yaml:"target" json:"target"`
-	Template   string            `yaml:"template,omitempty" json:"template,omitempty"`
-	Regex      string            `yaml:"regex,omitempty" json:"regex,omitempty"`
-	Default    interface{}       `yaml:"default,omitempty" json:"default,omitempty"`
-	Question   *qaengine.Problem `yaml:"question,omitempty" json:"question,omitempty"`
-	Filters    []FilterT         `yaml:"filters,omitempty" json:"filters,omitempty"`
-	Parameters []ParameterT      `yaml:"parameters,omitempty" json:"parameters,omitempty"`
+	Target                     string            `yaml:"target" json:"target"`
+	Template                   string            `yaml:"template,omitempty" json:"template,omitempty"`
+	Regex                      string            `yaml:"regex,omitempty" json:"regex,omitempty"`
+	KeepOriginalValueIfPresent bool              `yaml:"keepOriginalValueIfPresent,omitempty" json:"keepOriginalValueIfPresent,omitempty"`
+	Default                    interface{}       `yaml:"default,omitempty" json:"default,omitempty"`
+	Question                   *qaengine.Problem `yaml:"question,omitempty" json:"question,omitempty"`
+	Filters                    []FilterT         `yaml:"filters,omitempty" json:"filters,omitempty"`
+	Parameters                 []ParameterT      `yaml:"parameters,omitempty" json:"parameters,omitempty"`
 }
 
 // FilterT is used to choose the k8s resources that the parameterizer should be applied on

--- a/transformer/kubernetes/parameterizer/utils.go
+++ b/transformer/kubernetes/parameterizer/utils.go
@@ -342,6 +342,8 @@ func writeResourceStripQuotesAndAppendToFile(k8sResource k8sschema.K8sResourceT,
 
 // CollectParamsFromPath returns parameterizers found in a directory
 func CollectParamsFromPath(parameterizersDir string) (map[string][]ParameterizerT, error) {
+	logrus.Trace("CollectParamsFromPath start")
+	defer logrus.Trace("CollectParamsFromPath end")
 	yamlPaths, err := common.GetFilesByExt(parameterizersDir, []string{".yaml", ".yml"})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Bug

## Steps to reproduce

1. Run `move2kube plan -s src` and `move2kube transform`
2. Specify a different number of replicas
```
? Provide the minimum number of replicas each service should have
ID: move2kube.minreplicas
Hints:
- If the value is 0 pods won't be started by default

 33
```

## Expected behaviour

The output yamls and helm chart values.yaml should have the replicas set to `33`

## Actual behaviour

In the output `deploy/yamls/` all the `Deployment` yamls have the replicas set to `33`.
In the output `deploy/yamls-parameterized/` folder has Helm chart, Kustomize and Openshift Template all of which have replicas set to `2`.

This is because the `default` value in a parameterizer yaml always replaces the original value at the location.
https://github.com/konveyor/move2kube/blob/main/assets/built-in/transformers/kubernetes/parameterizer/parameterizers/replicas.yaml#L9

## Fix

Add a new option to allow keeping the original value if present.

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>