### PR TITLE
fix: use forward slashes for paths in Dockerfiles because backward slash is a special character

### DIFF
--- a/transformer/dockerfilegenerator/windows/webappdockerfilegenerator.go
+++ b/transformer/dockerfilegenerator/windows/webappdockerfilegenerator.go
@@ -358,7 +358,7 @@ func (t *WinWebAppDockerfileGenerator) Transform(newArtifacts []transformertypes
 				IncludeBuildStage:  selectedBuildOption == dotnetutils.BUILD_IN_EVERY_IMAGE,
 				IncludeRunStage:    true,
 				BuildContainerName: imageToCopyFrom,
-				CopyFrom:           copyFrom,
+				CopyFrom:           common.GetUnixPath(copyFrom),
 				RunStageImageTag:   t.getImageTagFromVersion(targetFrameworkVersion),
 			}
 


### PR DESCRIPTION
Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>