### PR TITLE
fix: Prevent docker build from failing if .npm folder is missing

### DIFF
--- a/assets/built-in/transformers/dockerfilegenerator/nodejs/templates/Dockerfile
+++ b/assets/built-in/transformers/dockerfilegenerator/nodejs/templates/Dockerfile
@@ -23,6 +23,7 @@ RUN {{ .PackageManager }} run build
 {{- end}}
 {{- if eq .PackageManager "npm" }}
 USER root
+RUN mkdir -p /opt/app-root/src/.npm
 RUN chown -R 1001:0 /opt/app-root/src/.npm
 RUN chmod -R 775 /opt/app-root/src/.npm
 USER 1001


### PR DESCRIPTION
```console
building image frontend
[+] Building 5.1s (9/10)                                                                           
 => [internal] load build definition from Dockerfile                                          0.1s
 => => transferring dockerfile: 868B                                                          0.0s
 => [internal] load .dockerignore                                                             0.0s
 => => transferring context: 56B                                                              0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi8/nodejs-14:latest             0.0s
 => [internal] load build context                                                             0.2s
 => => transferring context: 2.91MB                                                           0.1s
 => [1/6] FROM registry.access.redhat.com/ubi8/nodejs-14                                      0.1s
 => [2/6] COPY . .                                                                            0.2s
 => [3/6] RUN npm install                                                                     2.1s
 => [4/6] RUN npm run build                                                                   1.5s
 => ERROR [5/6] RUN chown -R 1001:0 /opt/app-root/src/.npm                                    0.8s
------                                                                                             
 > [5/6] RUN chown -R 1001:0 /opt/app-root/src/.npm:
#9 0.708 chown: cannot access '/opt/app-root/src/.npm': No such file or directory
------
executor failed running [/bin/sh -c chown -R 1001:0 /opt/app-root/src/.npm]: exit code: 1
```

We added a fix in the PR https://github.com/konveyor/move2kube/pull/905 to resolve the permission denied issue on OpenShift cluster, but now the docker build was failing. So, I have added a fix to prevent the docker build from failing.

```console
building image frontend
[+] Building 0.3s (12/12) FINISHED                                                                 
 => [internal] load build definition from Dockerfile                                          0.0s
 => => transferring dockerfile: 904B                                                          0.0s
 => [internal] load .dockerignore                                                             0.0s
 => => transferring context: 56B                                                              0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi8/nodejs-14:latest             0.0s
 => [1/7] FROM registry.access.redhat.com/ubi8/nodejs-14                                      0.0s
 => [internal] load build context                                                             0.1s
 => => transferring context: 2.91MB                                                           0.1s
 => CACHED [2/7] COPY . .                                                                     0.0s
 => CACHED [3/7] RUN npm install                                                              0.0s
 => CACHED [4/7] RUN npm run build                                                            0.0s
 => CACHED [5/7] RUN mkdir -p /opt/app-root/src/.npm                                          0.0s
 => CACHED [6/7] RUN chown -R 1001:0 /opt/app-root/src/.npm                                   0.0s
 => CACHED [7/7] RUN chmod -R 775 /opt/app-root/src/.npm                                      0.0s
 => exporting to image                                                                        0.0s
 => => exporting layers                                                                       0.0s
 => => writing image sha256:7072fd0069d5d8c10405bbc769ec02708c28905ee9cccf63497f25ca0268fd76  0.0s
 => => naming to docker.io/library/frontend 
 ```


Signed-off-by: Akash Nayak <akash19nayak@gmail.com>