### PR TITLE
fix: Do not add the image pull secret to the service IR if selected no authentication

### DIFF
--- a/transformer/kubernetes/irpreprocessor/registrypreprocessor.go
+++ b/transformer/kubernetes/irpreprocessor/registrypreprocessor.go
@@ -117,6 +117,7 @@ func (p registryPreProcessor) preprocess(ir irtypes.IR) (irtypes.IR, error) {
 	imagePullSecrets := map[string]string{} // registry url -> pull secret name
 	registryNamespace := commonqa.ImageRegistryNamespace()
 	useExistingPullSecret := false
+	createPullSecret := false
 	for _, registry := range usedRegistries {
 		if _, ok := imagePullSecrets[registry]; !ok {
 			imagePullSecrets[registry] = common.NormalizeForMetadataName(strings.ReplaceAll(registry, ".", "-") + imagePullSecretSuffix)
@@ -136,7 +137,6 @@ func (p registryPreProcessor) preprocess(ir irtypes.IR) (irtypes.IR, error) {
 		desc := fmt.Sprintf("[%s] What type of container registry login do you want to use?", registry)
 		hints := []string{"Docker login from config mode, will use the default config from your local machine."}
 		auth := qaengine.FetchSelectAnswer(quesKey, desc, hints, string(defaultOption), authOptions, nil)
-		createPullSecret := false
 		switch registryLoginOption(auth) {
 		case noLogin:
 			regAuth.Auth = ""
@@ -202,7 +202,7 @@ func (p registryPreProcessor) preprocess(ir irtypes.IR) (irtypes.IR, error) {
 				}
 			}
 			if !found {
-				if useExistingPullSecret {
+				if useExistingPullSecret || createPullSecret {
 					service.ImagePullSecrets = append(service.ImagePullSecrets, core.LocalObjectReference{Name: pullSecretName})
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/konveyor/move2kube/issues/928

The generated deployment yaml when selected `no authentication`.
```console
apiVersion: apps/v1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    move2kube.konveyor.io/service: nodejs
  name: nodejs
spec:
  progressDeadlineSeconds: 600
  replicas: 2
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      move2kube.konveyor.io/service: nodejs
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        move2kube.konveyor.io/service: nodejs
      name: nodejs
    spec:
      containers:
        - image: quay.io/latest4/nodejs:latest
          imagePullPolicy: Always
          name: nodejs
          ports:
            - containerPort: 8080
              protocol: TCP
          resources: {}
          terminationMessagePath: /dev/termination-log
          terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
status: {}
```

The generated deployment yaml when selected `use an existing pull secret` and gave `all-icr-io` as the pull secret.

```console
apiVersion: apps/v1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    move2kube.konveyor.io/service: nodejs
  name: nodejs
spec:
  progressDeadlineSeconds: 600
  replicas: 2
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      move2kube.konveyor.io/service: nodejs
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        move2kube.konveyor.io/service: nodejs
      name: nodejs
    spec:
      containers:
        - image: quay.io/latest3/nodejs:latest
          imagePullPolicy: Always
          name: nodejs
          ports:
            - containerPort: 8080
              protocol: TCP
          resources: {}
          terminationMessagePath: /dev/termination-log
          terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      imagePullSecrets:
        - name: all-icr-io
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
status: {}
```

Co-authored-by: Ashok Pon Kumar <ashokponkumar@gmail.com>
Signed-off-by: Akash Nayak <akash19nayak@gmail.com>