### PR TITLE
feat: Update the Golang Dockerfilegenerator transformer to support multi-arch build

### DIFF
--- a/assets/built-in/transformers/dockerfilegenerator/golang/mappings/golangversions.yaml
+++ b/assets/built-in/transformers/dockerfilegenerator/golang/mappings/golangversions.yaml
@@ -1,0 +1,20 @@
+apiVersion: move2kube.konveyor.io/v1alpha1
+kind: GolangVersionsMapping
+metadata:
+  name: GolangVersionsMapping
+spec:
+  golangVersions:
+    - version: "1.18"
+      imageTag: "1.18"
+    - version: "1.17"
+      imageTag: "1.17"
+    - version: "1.16"
+      imageTag: "1.16.12"
+    - version: "1.15"
+      imageTag: "1.15.14"
+    - version: "1.14"
+      imageTag: "1.14.12"
+    - version: "1.13"
+      imageTag: "1.13.15" 
+    - version: "1.12"
+      imageTag: "1.12.8"

--- a/assets/built-in/transformers/dockerfilegenerator/golang/templates/Dockerfile
+++ b/assets/built-in/transformers/dockerfilegenerator/golang/templates/Dockerfile
@@ -13,22 +13,14 @@
 #   limitations under the License.
 
 # Build App
-FROM registry.access.redhat.com/ubi8/ubi:latest AS builder
-WORKDIR /temp
-ENV GOPATH=/go
-ENV PATH=$GOPATH/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-RUN curl -o go.tar.gz https://dl.google.com/go/go{{ .GoVersion }}.linux-amd64.tar.gz
-RUN tar -xzf go.tar.gz && mv go /usr/local/
-RUN yum install git make -y 
-RUN mkdir -p $GOPATH/src $GOPATH/bin && chmod -R 777 $GOPATH
+FROM registry.access.redhat.com/ubi8/go-toolset:{{ .GolangImageTag }} AS builder
 WORKDIR /{{ .AppName }}
 COPY . .
-RUN go build -o {{ .AppName }}
-RUN cp ./{{ .AppName }} /bin/{{ .AppName }}
+RUN go build -o ./bin/{{ .AppName }}
 
 # Run App
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-201
-COPY --from=builder /bin/{{ .AppName }} /bin/{{ .AppName }}
+COPY --from=builder /{{ .AppName }}/bin/{{ .AppName }} /bin/{{ .AppName }}
 {{- range $port := .Ports }}
 EXPOSE {{ $port }}
 {{- end }}

--- a/assets/built-in/transformers/dockerfilegenerator/golang/transformer.yaml
+++ b/assets/built-in/transformers/dockerfilegenerator/golang/transformer.yaml
@@ -19,3 +19,5 @@ spec:
       disabled: false
   config:
     defaultGoVersion: "1.18"
+  externalFiles:
+    "./mappings/golangversions.yaml" : mappings/golangversions.yaml

--- a/assets/filepermissions.yaml
+++ b/assets/filepermissions.yaml
@@ -34,6 +34,7 @@
 "built-in/transformers/dockerfilegenerator/common/Dockerfile.license" : 0644
 "built-in/transformers/dockerfilegenerator/dotnetcore/templates/Dockerfile" : 0644
 "built-in/transformers/dockerfilegenerator/dotnetcore/transformer.yaml" : 0644
+"built-in/transformers/dockerfilegenerator/golang/mappings/golangversions.yaml" : 0644
 "built-in/transformers/dockerfilegenerator/golang/templates/Dockerfile" : 0644
 "built-in/transformers/dockerfilegenerator/golang/transformer.yaml" : 0644
 "built-in/transformers/dockerfilegenerator/java/earanalyser/transformer.yaml" : 0644


### PR DESCRIPTION
Changed the base image to [registry.access.redhat.com/ubi8/go-toolset](https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1) for building the app with multi-arch support. The base image supports amd64/arm64/ppc64le/s390x.

I was successfully able to build the multi-arch image for amd64, arm64 and ppc64le (Power), but for s390x (Z) arch the build gets stuck at `RUN go build -o ./bin/golang`.

<img width="1205" alt="golang-s390x-build-stuck" src="https://user-images.githubusercontent.com/14867323/211329809-79db04ff-6ba5-46c8-a6ae-4c25953139c3.png">

```console
➜  scripts git:(main) ✗ ./buildandpushimages_multiarch.sh quay.io akashnayak linux/amd64,linux/arm64,linux/ppc64le
building and pushing image golang
[+] Building 60.7s (29/29) FINISHED                                                                     
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load build definition from Dockerfile                                               0.0s
 => => transferring dockerfile: 919B                                                               0.0s
 => [linux/arm64 internal] load metadata for registry.access.redhat.com/ubi8/ubi-minimal:8.3-201   2.7s
 => [linux/ppc64le internal] load metadata for registry.access.redhat.com/ubi8/ubi-minimal:8.3-20  2.8s
 => [linux/ppc64le internal] load metadata for registry.access.redhat.com/ubi8/go-toolset:1.16.12  2.6s
 => [linux/arm64 internal] load metadata for registry.access.redhat.com/ubi8/go-toolset:1.16.12    3.1s
 => [linux/amd64 internal] load metadata for registry.access.redhat.com/ubi8/go-toolset:1.16.12    3.2s
 => [linux/amd64 internal] load metadata for registry.access.redhat.com/ubi8/ubi-minimal:8.3-201   3.2s
 => [linux/arm64 builder 1/4] FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12@sha256:02f3  0.0s
 => => resolve registry.access.redhat.com/ubi8/go-toolset:1.16.12@sha256:02f3a14a5da5d31d84ff7024  0.0s
 => [linux/ppc64le builder 1/4] FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12@sha256:02  0.1s
 => => resolve registry.access.redhat.com/ubi8/go-toolset:1.16.12@sha256:02f3a14a5da5d31d84ff7024  0.1s
 => [linux/arm64 stage-1 1/2] FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-201@sha256:c64  0.0s
 => => resolve registry.access.redhat.com/ubi8/ubi-minimal:8.3-201@sha256:c6473956faa4985a4177670  0.1s
 => => sha256:4ee348554246a67f2ff154f1d013791537c91be2622b1629c1c090a9062ee1d0 38.92MB / 38.92MB   3.7s
 => => extracting sha256:4ee348554246a67f2ff154f1d013791537c91be2622b1629c1c090a9062ee1d0          2.1s
 => => extracting sha256:74f4d11444244c906adeed562ee9b79a53d9b70dddd69aff036d91bfb1046a7a          0.0s
 => [linux/ppc64le stage-1 1/2] FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-201@sha256:c  0.1s
 => => resolve registry.access.redhat.com/ubi8/ubi-minimal:8.3-201@sha256:c6473956faa4985a4177670  0.1s
 => [linux/amd64 builder 1/4] FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12@sha256:02f3  5.2s
 => => resolve registry.access.redhat.com/ubi8/go-toolset:1.16.12@sha256:02f3a14a5da5d31d84ff7024  0.1s
 => => sha256:bc0678604f4ccd27f1d623736cfa7b978f2b8807215c16c7545cff150137d3 144.10MB / 144.10MB  13.1s
 => => sha256:7b8efddf55ed035efb83c57cf21362b76d1cffb2c88864f11de91ee823c86a 143.01MB / 143.01MB  26.0s
 => => extracting sha256:7b8efddf55ed035efb83c57cf21362b76d1cffb2c88864f11de91ee823c86afa          6.2s
 => => extracting sha256:bc0678604f4ccd27f1d623736cfa7b978f2b8807215c16c7545cff150137d332          5.2s
 => [internal] load build context                                                                  0.0s
 => => transferring context: 84B                                                                   0.0s
 => [linux/amd64 stage-1 1/2] FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-201@sha256:c64  0.0s
 => => resolve registry.access.redhat.com/ubi8/ubi-minimal:8.3-201@sha256:c6473956faa4985a4177670  0.1s
 => => sha256:c0194df27effde85019e70c3b7a3f2571c3aabe30f5b0c96c86ed528a0ca06c1 1.73kB / 1.73kB     1.2s
 => => sha256:4753a4528f5f857083f7c31ba761a3ed67c0005660cc488d96b1b80165946a38 39.38MB / 39.38MB   8.2s
 => => extracting sha256:4753a4528f5f857083f7c31ba761a3ed67c0005660cc488d96b1b80165946a38          1.7s
 => => extracting sha256:c0194df27effde85019e70c3b7a3f2571c3aabe30f5b0c96c86ed528a0ca06c1          0.0s
 => CACHED [linux/arm64 builder 2/4] WORKDIR /golang                                               0.0s
 => CACHED [linux/arm64 builder 3/4] COPY . .                                                      0.0s
 => CACHED [linux/arm64 builder 4/4] RUN go build -o ./bin/golang                                  0.0s
 => CACHED [linux/ppc64le builder 2/4] WORKDIR /golang                                             0.0s
 => CACHED [linux/ppc64le builder 3/4] COPY . .                                                    0.0s
 => CACHED [linux/ppc64le builder 4/4] RUN go build -o ./bin/golang                                0.0s
 => CACHED [linux/ppc64le stage-1 2/2] COPY --from=builder /golang/bin/golang /bin/golang          0.0s
 => [linux/arm64 stage-1 2/2] COPY --from=builder /golang/bin/golang /bin/golang                   0.3s
 => [linux/amd64 builder 2/4] WORKDIR /golang                                                      0.6s
 => [linux/amd64 builder 3/4] COPY . .                                                             0.0s
 => [linux/amd64 builder 4/4] RUN go build -o ./bin/golang                                         0.8s
 => [linux/amd64 stage-1 2/2] COPY --from=builder /golang/bin/golang /bin/golang                   0.1s
 => exporting to image                                                                            17.0s
 => => exporting layers                                                                            0.4s
 => => exporting manifest sha256:9e99b280ff366804d4ce10b1625f06ff20fa61cbbb7347fd8f74ec1d1b45ed50  0.0s
 => => exporting config sha256:709b008f5a9122c063486387a627c52adfd7b64fd87fb64e481fa97dbaad9fc6    0.0s
 => => exporting manifest sha256:782a848462fad9b05b52de0dea2791a102d2c9d0bd3532740775a4683c4361a0  0.0s
 => => exporting config sha256:29b60a01023ca6a59662d59921bff566ea1d178f347afefea99148c7e5daaaa6    0.0s
 => => exporting manifest sha256:8bf67a4bc314b945052440e3533116f2791a3606ed9af81afdeee1931bb253c5  0.0s
 => => exporting config sha256:3e09a4620c2b3d54f681671e101823e82eca0ec4925c92eefa4001f333735369    0.0s
 => => exporting manifest list sha256:cbb73dbf139704adcf7d8bed60ff2613cf0e162b463ac481401e6c88987  0.0s
 => => pushing layers                                                                             11.5s
 => => pushing manifest for quay.io/akashnayak/golang:latest@sha256:cbb73dbf139704adcf7d8bed60ff2  5.0s
 => [auth] akashnayak/golang:pull,push token for quay.io                                           0.0s
/Users/akash/github/move2kube-demos/samples/language-platforms/myproject
done
```

<img width="1363" alt="Screenshot 2023-01-09 at 8 07 06 PM" src="https://user-images.githubusercontent.com/14867323/211333406-731639b6-9397-4a45-9c76-3a6f9522f05c.png">


Also, tested the deployment on OpenShift cluster with the multi-arch image.

<img width="975" alt="Screenshot 2023-01-09 at 7 57 44 PM" src="https://user-images.githubusercontent.com/14867323/211331382-84516926-4ac4-4789-9485-39d44247f013.png">


Signed-off-by: Akash Nayak <akash19nayak@gmail.com>