### PR TITLE
fix: Resolve panic error in Zuul analyser for path not ending with double asterisk

### DIFF
--- a/transformer/dockerfilegenerator/java/zuulanalyser.go
+++ b/transformer/dockerfilegenerator/java/zuulanalyser.go
@@ -17,6 +17,8 @@
 package java
 
 import (
+	"strings"
+
 	"github.com/konveyor/move2kube/common"
 	"github.com/konveyor/move2kube/environment"
 	irtypes "github.com/konveyor/move2kube/types/ir"
@@ -62,7 +64,7 @@ func (t *ZuulAnalyser) Init(tc transformertypes.Transformer, env *environment.En
 		}
 		for servicename, routepath := range z.ZuulSpec.RouteSpec {
 			// TODO: routepath (ant style) to regex
-			routepath = routepath[:len(routepath)-2]
+			routepath = strings.TrimSuffix(routepath, "**")
 			t.services[servicename] = routepath
 		}
 	}


### PR DESCRIPTION
There was a panic error if the zuul path is `/` and not `/**`.
```yaml
zuul:
  routes:
    api: /api/**
    web: /
```

```console
$ move2kube plan -s docker-compose-services
panic: runtime error: slice bounds out of range [:-1]

goroutine 1 [running]:
github.com/konveyor/move2kube/transformer/dockerfilegenerator/java.(*ZuulAnalyser).Init(0xc0008aeb00, {{{0xc0010edb20, 0x1e}, {0xc0010d2ef0, 0xb}}, {{0xc0010d2f24, 0xc}, 0xc0010ee810}, {{0xc0009f3040, 0x92}, ...}}, ...)
	/Users/akash/github/move2kube/transformer/dockerfilegenerator/java/zuulanalyser.go:65 +0x409
github.com/konveyor/move2kube/transformer.InitTransformers(0xc000f98fb8?, {0x3c3b9b8, 0xc00048c150}, {0xc00015a0a0, 0x41}, {0x0, 0x0}, {0x3634ba9, 0x9}, 0x0, ...)
```

This PR fixes the above panic error.

```console
$ move2kube plan -s docker-compose-services
INFO[0000] Configuration loading done                   
INFO[0000] Start planning                               
INFO[0000] Planning started on the base directory       
INFO[0000] [DockerfileDetector] Planning                
INFO[0000] Identified 1 named services and 1 to-be-named services 
INFO[0000] [DockerfileDetector] Done                    
INFO[0000] [ComposeAnalyser] Planning                   
INFO[0000] Identified 3 named services and 0 to-be-named services 
INFO[0000] [ComposeAnalyser] Done                       
INFO[0000] [CloudFoundry] Planning                      
INFO[0000] [CloudFoundry] Done                          
INFO[0000] [Base Directory] Identified 4 named services and 1 to-be-named services 
INFO[0000] Planning finished on the base directory      
INFO[0000] Planning started on its sub directories      
INFO[0000] Identified 1 named services and 0 to-be-named services in api 
INFO[0000] Identified 1 named services and 0 to-be-named services in web 
INFO[0000] Planning finished on its sub directories     
INFO[0000] [Directory Walk] Identified 4 named services and 1 to-be-named services 
INFO[0000] [Named Services] Identified 3 named services 
INFO[0000] Planning done                                
INFO[0000] No of services identified : 3                
INFO[0000] Plan can be found at [/Users/akash/docker-compose-2-ocp/m2k.plan].
```

Signed-off-by: Akash Nayak <akash19nayak@gmail.com>