### PR TITLE
feat: show the call stack and line numbers when an error occurs while running starlark functions like transform

### DIFF
--- a/transformer/external/starlarktransformer.go
+++ b/transformer/external/starlarktransformer.go
@@ -190,6 +190,10 @@ func (t *Starlark) Transform(
 	}
 	val, err := starlark.Call(t.StarThread, t.transformFn, starlark.Tuple{starNewArtifacts, starOldArtifacts}, nil)
 	if err != nil {
+		switch err := err.(type) {
+		case *starlark.EvalError:
+			return nil, nil, fmt.Errorf("failed to call the starlark function '%s' . The call stack is:\n%s\nError: %w", t.transformFn.String(), err.Backtrace(), err)
+		}
 		return nil, nil, fmt.Errorf("failed to call the starlark function '%s' . Error: %w", t.transformFn.String(), err)
 	}
 	valI, err := starutil.Unmarshal(val)

--- a/transformer/transformer.go
+++ b/transformer/transformer.go
@@ -589,7 +589,8 @@ func transform(newArtifactsToProcess, allArtifacts []transformertypes.Artifact, 
 
 		producedNewPathMappings, producedNewArtifacts, err := runSingleTransform(artifactsToConsume, allArtifacts, transformer, tConfig, env, graph, iteration)
 		if err != nil {
-			logrus.Errorf("failed to run a single transformation using the transformer %+v on the artifacts %+v . Error: %q", tConfig, artifactsToConsume, err)
+			logrus.Errorf("failed to run a single transformation using the transformer %+v on the artifacts: %+v", tConfig, artifactsToConsume)
+			logrus.Error(err.Error())
 			continue
 		}
 		pathMappings = append(pathMappings, producedNewPathMappings...)
@@ -686,7 +687,10 @@ func runSingleTransform(artifactsToProcess, allArtifacts []transformertypes.Arti
 	// logging
 
 	if err != nil {
-		return newPathMappings, newArtifacts, fmt.Errorf("failed to transform artifacts using the transformer %s . Error: %q", tconfig.Name, err)
+		return newPathMappings, newArtifacts, fmt.Errorf(
+			"failed to transform artifacts using the transformer named '%s' . Error: %w",
+			tconfig.Name, err,
+		)
 	}
 
 	filteredArtifacts := []transformertypes.Artifact{}


### PR DESCRIPTION
Example bug in a Starlark transformer:
```
                    if 'HostPath' in v:
                        path = v['HostPath']['Path']
```

and error output shows the exact line number and the starlark file name:
```
ERRO[0000] failed to transform artifacts using the transformer named 'ConfigMapGen' . Error: failed to call the starlark function '<function transform>' . The call stack is:
Traceback (most recent call last):
  /var/folders/dt/y3srs7vs6pz9bqwrbjwt38pc0000gp/T/move2kube313903856/m2kassets/custom/cfg-map-generator/configmapgen.star:49:45: in transform
Error: unhandled index operation NoneType[string]
Error: unhandled index operation NoneType[string] 
```