### PR TITLE
fix: set-output throws error in ci/cd starting June 2023

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,9 +86,9 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF#refs/heads/}"
           if [ "$BRANCH" == 'main' ] ; then
-            echo "::set-output name=tag::latest"
+            echo "tag=latest" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=tag::$BRANCH"
+            echo "tag=$BRANCH" >> $GITHUB_OUTPUT
           fi
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           ref: ${{ github.event.inputs.commit_ref }}
       - id: get_sha
         run: |
-          echo "::set-output name=sha::$(git rev-parse HEAD)"
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.MOVE2KUBE_PATOKEN }}


### PR DESCRIPTION
This is required as set-output would be completely removed and the workflows can potentially break starting June 2023.

Fyi - 
I am new to open source, however, I have some working knowledge on git and enterprise github.

I tried following the conventions as much as possible, please guide me if I have missed anything in this pull request.

thank you.