### PR TITLE
fix: panic in dotnetcore transformer when publish profile XML files are specified

### DIFF
--- a/types/source/maven/pom.go
+++ b/types/source/maven/pom.go
@@ -68,11 +68,9 @@ type Pom struct {
 }
 
 // Load loads a pom xml file
-func (pom *Pom) Load(file string) error {
-	err := common.ReadXML(file, pom)
-	if err != nil {
-		logrus.Errorf("Unable to unmarshal pom file (%s) : %s", file, err)
-		return err
+func (pom *Pom) Load(pomPath string) error {
+	if err := common.ReadXML(pomPath, pom); err != nil {
+		return fmt.Errorf("failed to unmarshal the POM file at path '%s' as XML. Error: %w", pomPath, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Also fixes an error that was shown when the `.csproj` file doesn't contain a `ItemGroup` element.