### PR TITLE
fix: panic when run on docker compose single service sample because []interface{} is not []string

### DIFF
--- a/transformer/compose/composeanalyser.go
+++ b/transformer/compose/composeanalyser.go
@@ -128,7 +128,11 @@ func (t *ComposeAnalyser) Transform(newArtifacts []transformertypes.Artifact, al
 			logrus.Debugf("failed to load config for Transformer into %T . Error: %q", imageName, err)
 		}
 		ir := irtypes.NewIR()
-		composeFiles := newArtifact.Configs[ComposeFileConfigType].([]string)
+		composeFiles := []string{}
+		if err := newArtifact.GetConfig(ComposeFileConfigType, &composeFiles); err != nil {
+			logrus.Errorf("failed to get the compose files from the artifact. Error: %+q", err)
+			continue
+		}
 		for _, composeFileName := range composeFiles {
 			composeFilePath := filepath.Join(newArtifact.Paths[dockerComposeContextPathType][0], composeFileName)
 			logrus.Debugf("file at path '%s' being loaded from the compose service name '%s'", composeFilePath, config.ServiceName)


### PR DESCRIPTION
```console
$ move2kube plan -s single-service/
INFO[0000] Configuration loading done                   
INFO[0000] Start planning                               
INFO[0000] Planning started on the base directory: '....../single-service' 
INFO[0000] [CloudFoundry] Planning                      
INFO[0000] [CloudFoundry] Done                          
INFO[0000] [ComposeAnalyser] Planning                   
INFO[0000] Identified 1 named services and 0 to-be-named services 
INFO[0000] [ComposeAnalyser] Done                       
INFO[0000] [DockerfileDetector] Planning                
INFO[0000] [DockerfileDetector] Done                    
INFO[0000] [Base Directory] Identified 1 named services and 0 to-be-named services 
INFO[0000] Planning finished on the base directory: '....../single-service' 
INFO[0000] Planning started on its sub directories      
INFO[0000] Planning finished on its sub directories     
INFO[0000] [Directory Walk] Identified 1 named services and 0 to-be-named services 
INFO[0000] [Named Services] Identified 1 named services 
INFO[0000] Planning done. Number of services identified: 1 
INFO[0000] Plan can be found at [....../m2k.plan].
$ move2kube transform
INFO[0000] Detected a plan file at path ....../m2k.plan. Will transform using this plan. 
INFO[0000] Starting transformation                      
? Specify a Kubernetes style selector to select only the transformers that you want to run.
ID: move2kube.transformerselector
Hints:
- Leave empty to select everything. This is the default.

 
? Select all transformer types that you are interested in:
ID: move2kube.transformers.types
Hints:
- Services that don't support any of the transformer types you are interested in will be ignored.

 ArgoCD, Buildconfig, CloudFoundry, ClusterSelector, ComposeAnalyser, ComposeGenerator, ContainerImagesPushScriptGenerator, DockerfileDetector, DockerfileImageBuildScript, DockerfileParser, DotNetCore-Dockerfile, EarAnalyser, EarRouter, Golang-Dockerfile, Gradle, Jar, Jboss, Knative, Kubernetes, KubernetesVersionChanger, Liberty, Maven, Nodejs-Dockerfile, OperatorTransformer, PHP-Dockerfile, Parameterizer, Python-Dockerfile, ReadMeGenerator, Ruby-Dockerfile, Rust-Dockerfile, Tekton, Tomcat, WarAnalyser, WarRouter, WinWebApp-Dockerfile, ZuulAnalyser
? Select all services that are needed:
ID: move2kube.services.[].enable
Hints:
- The services unselected here will be ignored.

 web
INFO[0001] Using the transformation option 'ComposeAnalyser' for the service 'web'. 
INFO[0001] Iteration 1                                  
INFO[0001] Iteration 2 - 1 artifacts to process         
INFO[0001] Transformer 'ComposeAnalyser' processing 1 artifacts 
panic: interface conversion: interface {} is []interface {}, not []string

goroutine 1 [running]:
github.com/konveyor/move2kube/transformer/compose.(*ComposeAnalyser).Transform(0xc000749a00, {0xc00011f770, 0x1, 0x0?}, {0x0?, 0x0?, 0x3293a80?})
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/transformer/compose/composeanalyser.go:131 +0x2009
github.com/konveyor/move2kube/transformer.runSingleTransform({_, _, _}, {_, _, _}, {_, _}, {{{0xc000657360, 0x1e}, ...}, ...}, ...)
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/transformer/transformer.go:668 +0x2af
github.com/konveyor/move2kube/transformer.transform({0xc00011f540, 0x1, 0x1}, {0xc00011f540, 0x1, 0x1}, 0x0, {0x0, 0x0}, 0xc000e37140, ...)
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/transformer/transformer.go:617 +0xd25
github.com/konveyor/move2kube/transformer.Transform({0xc000a96850, 0x1, 0x3704597?}, {0xc000b9fa00, 0x3e}, {0xc000b9fac0, 0x39})
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/transformer/transformer.go:549 +0x654
github.com/konveyor/move2kube/lib.Transform({0xc000b9e000?, 0x38?}, {{{0xc000478700, 0x1e}, {0xc00023b1fc, 0x4}}, {{0xc00023b224, 0x9}, 0x0}, {{0xc000b9fa00, ...}, ...}}, ...)
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/lib/transformer.go:102 +0x4db
github.com/konveyor/move2kube/cmd.transformHandler(_, {{0x0, 0x0, {0x3656fcd, 0x1}, {0x3656fcd, 0x1}, {0x549c508, 0x0, 0x0}, ...}, ...})
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/cmd/transform.go:187 +0x153c
github.com/konveyor/move2kube/cmd.GetTransformCommand.func2(0xc00088f400?, {0x36587d6?, 0x0?, 0x0?})
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/cmd/transform.go:207 +0x58
github.com/spf13/cobra.(*Command).execute(0xc00088f400, {0x549c508, 0x0, 0x0})
	/Users/user/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:860 +0x663
github.com/spf13/cobra.(*Command).ExecuteC(0xc00088ea00)
	/Users/user/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:974 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/user/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:902
main.main()
	/Users/user/Documents/code/remote/github.com/konveyor/move2kube/main.go:43 +0x21b

```