### PR TITLE
feat: add a flag to limit the maximum number of iterations

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -43,6 +43,8 @@ const (
 	preSetFlag = "preset"
 	// overwriteFlag is the name of the flag that lets you overwrite the output directory if it exists
 	overwriteFlag = "overwrite"
+	// maxIterationsFlag is the name of the flag that lets you set the maximum number of iterations to allow
+	maxIterationsFlag = "max-iterations"
 	// customizationsFlag is the path to customizations directory
 	customizationsFlag      = "customizations"
 	qadisablecliFlag        = "qa-disable-cli"
@@ -52,8 +54,10 @@ const (
 )
 
 type qaflags struct {
+	// qadisablecli disables the CLI engine. To be used with HTTP REST engine
 	qadisablecli bool
-	qaport       int
+	// qaport contains the port where the Question Answer HTTP REST engine server is started
+	qaport int
 	// configOut contains the location to output the config
 	configOut string
 	// qaCacheOut contains the location to output the cache

--- a/cmd/transform.go
+++ b/cmd/transform.go
@@ -46,6 +46,8 @@ type transformFlags struct {
 	name string
 	// overwrite lets you overwrite the output directory if it exists
 	overwrite bool
+	// maxIterations is the maximum number of iterations to allow before aborting with an error
+	maxIterations int
 	// CustomizationsPaths contains the path to the customizations directory
 	customizationsPath  string
 	transformerSelector string
@@ -184,7 +186,7 @@ func transformHandler(cmd *cobra.Command, flags transformFlags) {
 		}
 		startQA(flags.qaflags)
 	}
-	if err := lib.Transform(ctx, transformationPlan, preExistingPlan, flags.outpath, flags.transformerSelector); err != nil {
+	if err := lib.Transform(ctx, transformationPlan, preExistingPlan, flags.outpath, flags.transformerSelector, flags.maxIterations); err != nil {
 		logrus.Fatalf("failed to transform. Error: %q", err)
 	}
 	logrus.Infof("Transformed target artifacts can be found at [%s].", flags.outpath)
@@ -227,6 +229,7 @@ func GetTransformCommand() *cobra.Command {
 	// Advanced options
 	transformCmd.Flags().BoolVar(&flags.ignoreEnv, ignoreEnvFlag, false, "Ignore data from local machine.")
 	transformCmd.Flags().BoolVar(&flags.disableLocalExecution, common.DisableLocalExecutionFlag, false, "Allow files to be executed locally.")
+	transformCmd.Flags().IntVar(&flags.maxIterations, maxIterationsFlag, -1, "The maximum number of iterations to allow. Negative value means infinite. Default is -1.")
 
 	// Hidden options
 	transformCmd.Flags().BoolVar(&flags.qadisablecli, qadisablecliFlag, false, "Enable/disable the QA Cli sub-system. Without this system, you will have to use the REST API to interact.")

--- a/lib/transformer.go
+++ b/lib/transformer.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Transform transforms the artifacts and writes output
-func Transform(ctx context.Context, plan plantypes.Plan, preExistingPlan bool, outputPath string, transformerSelector string) error {
+func Transform(ctx context.Context, plan plantypes.Plan, preExistingPlan bool, outputPath string, transformerSelector string, maxIterations int) error {
 	logrus.Infof("Starting transformation")
 
 	common.ProjectName = plan.Name
@@ -99,7 +99,7 @@ func Transform(ctx context.Context, plan plantypes.Plan, preExistingPlan bool, o
 	}
 
 	// transform the selected services using the selected transformation options
-	if err := transformer.Transform(selectedTransformationOptions, plan.Spec.SourceDir, outputPath); err != nil {
+	if err := transformer.Transform(selectedTransformationOptions, plan.Spec.SourceDir, outputPath, maxIterations); err != nil {
 		return fmt.Errorf("failed to transform using the plan. Error: %w", err)
 	}
 

--- a/transformer/transformer.go
+++ b/transformer/transformer.go
@@ -509,7 +509,7 @@ func preprocessArtifact(planArtifact plantypes.PlanArtifact) plantypes.PlanArtif
 }
 
 // Transform transforms as per the plan
-func Transform(planArtifacts []plantypes.PlanArtifact, sourceDir, outputPath string) error {
+func Transform(planArtifacts []plantypes.PlanArtifact, sourceDir, outputPath string, maxIterations int) error {
 	logrus.Trace("transformer.Transform start")
 	defer logrus.Trace("transformer.Transform end")
 	var allArtifacts []transformertypes.Artifact
@@ -545,6 +545,10 @@ func Transform(planArtifacts []plantypes.PlanArtifact, sourceDir, outputPath str
 
 	for {
 		iteration++
+		if maxIterations >= 0 && iteration > maxIterations {
+			logrus.Errorf("exceeded the max number of iterations: %d . stopping.", maxIterations)
+			break
+		}
 		logrus.Infof("Iteration %d - %d artifacts to process", iteration, len(newArtifactsToProcess))
 		newPathMappings, newArtifacts, _ := transform(newArtifactsToProcess, allArtifacts, consume, nil, graph, iteration)
 		pathMappings = append(pathMappings, newPathMappings...)


### PR DESCRIPTION
```console
$ move2kube transform -s src/ -c cust/
........................
INFO[0013] Transformer 'Parameterizer' processing 4 artifacts 
INFO[0013] Transformer Parameterizer Done               
INFO[0013] Transformer 'ReadMeGenerator' processing 4 artifacts 
INFO[0013] Transformer ReadMeGenerator Done             
INFO[0013] Transformer 'ClusterSelector' processing 1 artifacts 
INFO[0013] Transformer ClusterSelector Done             
INFO[0013] Transformer 'Tekton' processing 1 artifacts  
INFO[0013] Transformer Tekton Done                      
INFO[0014] Created 31 pathMappings and 5 artifacts. Total Path Mappings : 176. Total Artifacts : 47. 
ERRO[0014] exceeded the max number of iterations: 10 . stopping. 
INFO[0014] Transformation done                          
INFO[0014] Transformed target artifacts can be found at [..................../myproject]. 
$ ls
cust  myproject  src  m2k-graph.json  m2k.plan  m2kconfig.yaml  m2kqacache.yaml
$ move2kube graph
INFO[0000] Listening on http://127.0.0.1:8080/
```

<img width="1491" alt="image" src="https://user-images.githubusercontent.com/20921177/229720546-cb5e5807-2aee-40cc-a6f3-ec9945b17d33.png">
