### PR TITLE
fix: Resolve docker build failure of NodeJS application

### DIFF
--- a/assets/built-in/transformers/dockerfilegenerator/nodejs/templates/Dockerfile
+++ b/assets/built-in/transformers/dockerfilegenerator/nodejs/templates/Dockerfile
@@ -14,6 +14,13 @@
 
 FROM registry.access.redhat.com/ubi8/nodejs-{{ .NodeMajorVersion }}
 COPY . .
+{{- if eq .PackageManager "npm" }}
+USER root
+RUN mkdir -p /opt/app-root/src/.npm
+RUN chown -R 1001:0 /opt/app-root/src/
+RUN chmod -R 775 /opt/app-root/src/
+USER 1001
+{{- end }}
 {{- if eq .PackageManager "yarn" }}
 RUN npm install --global yarn
 {{- end }}
@@ -21,12 +28,5 @@ RUN {{ .PackageManager }} install
 {{- if .Build }}
 RUN {{ .PackageManager }} run build
 {{- end}}
-{{- if eq .PackageManager "npm" }}
-USER root
-RUN mkdir -p /opt/app-root/src/.npm
-RUN chown -R 1001:0 /opt/app-root/src/.npm
-RUN chmod -R 775 /opt/app-root/src/.npm
-USER 1001
-{{- end }}
 EXPOSE {{ .Port }}
 CMD {{ .PackageManager }} run start


### PR DESCRIPTION
Fixes- https://github.com/konveyor/move2kube/issues/1016

Old Dockerfile
```dockerfile
FROM registry.access.redhat.com/ubi8/nodejs-16
COPY . .
RUN npm install
USER root
RUN mkdir -p /opt/app-root/src/.npm
RUN chown -R 1001:0 /opt/app-root/src/.npm
RUN chmod -R 775 /opt/app-root/src/.npm
USER 1001
EXPOSE 8080
CMD npm run start
```

```console
✗ ./buildimages.sh
building image cfnodejsapp
[+] Building 1.2s (7/10)                                                                           
 => [internal] load build definition from Dockerfile                                          0.0s
 => => transferring dockerfile: 879B                                                          0.0s
 => [internal] load .dockerignore                                                             0.0s
 => => transferring context: 2B                                                               0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi8/nodejs-16:latest             0.0s
 => [internal] load build context                                                             0.0s
 => => transferring context: 1.00kB                                                           0.0s
 => CACHED [1/6] FROM registry.access.redhat.com/ubi8/nodejs-16                               0.0s
 => [2/6] COPY . .                                                                            0.0s
 => ERROR [3/6] RUN npm install                                                               1.0s
------
 > [3/6] RUN npm install:
#7 0.893 npm WARN ancient lockfile 
#7 0.894 npm WARN ancient lockfile The package-lock.json file was created with an old version of npm,
#7 0.894 npm WARN ancient lockfile so supplemental metadata must be fetched from the registry.
#7 0.895 npm WARN ancient lockfile 
#7 0.895 npm WARN ancient lockfile This is a one-time fix-up, please be patient...
#7 0.896 npm WARN ancient lockfile 
#7 0.918 npm ERR! code EACCES
#7 0.918 npm ERR! syscall open
#7 0.919 npm ERR! path /opt/app-root/src/package-lock.json
#7 0.920 npm ERR! errno -13
#7 0.925 npm ERR! Error: EACCES: permission denied, open '/opt/app-root/src/package-lock.json'
#7 0.925 npm ERR!  [Error: EACCES: permission denied, open '/opt/app-root/src/package-lock.json'] {
#7 0.925 npm ERR!   errno: -13,
#7 0.925 npm ERR!   code: 'EACCES',
#7 0.926 npm ERR!   syscall: 'open',
#7 0.926 npm ERR!   path: '/opt/app-root/src/package-lock.json'
#7 0.926 npm ERR! }
#7 0.926 npm ERR! 
#7 0.926 npm ERR! The operation was rejected by your operating system.
#7 0.926 npm ERR! It is likely you do not have the permissions to access this file as the current user
#7 0.926 npm ERR! 
#7 0.926 npm ERR! If you believe this might be a permissions issue, please double-check the
#7 0.926 npm ERR! permissions of the file and its containing directories, or try running
#7 0.926 npm ERR! the command again as root/Administrator.
#7 0.929 
#7 0.929 npm ERR! A complete log of this run can be found in:
#7 0.929 npm ERR!     /opt/app-root/src/.npm/_logs/2023-04-06T10_45_50_809Z-debug-0.log
------
executor failed running [/bin/sh -c npm install]: exit code: 243
/Users/akash/move2kube-demos/samples/myproject3
done
```

New Dockerfile
```dockerfile
FROM registry.access.redhat.com/ubi8/nodejs-16
COPY . .
USER root
RUN mkdir -p /opt/app-root/src/.npm
RUN chown -R 1001:0 /opt/app-root/src/
RUN chmod -R 775 /opt/app-root/src/
USER 1001
RUN npm install
EXPOSE 8080
CMD npm run start
```

```console
✗ ./buildimages.sh
building image cfnodejsapp
[+] Building 4.7s (11/11) FINISHED                                                                 
 => [internal] load build definition from Dockerfile                                          0.6s
 => => transferring dockerfile: 878B                                                          0.1s
 => [internal] load .dockerignore                                                             0.5s
 => => transferring context: 2B                                                               0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi8/nodejs-16:latest             0.0s
 => [internal] load build context                                                             0.5s
 => => transferring context: 2.17kB                                                           0.2s
 => [1/6] FROM registry.access.redhat.com/ubi8/nodejs-16                                      0.0s
 => CACHED [2/6] COPY . .                                                                     0.0s
 => CACHED [3/6] RUN mkdir -p /opt/app-root/src/.npm                                          0.0s
 => CACHED [4/6] RUN chown -R 1001:0 /opt/app-root/src/                                       0.0s
 => CACHED [5/6] RUN chmod -R 775 /opt/app-root/src/                                          0.0s
 => CACHED [6/6] RUN npm install                                                              0.0s
 => exporting to image                                                                        0.5s
 => => exporting layers                                                                       0.0s
 => => writing image sha256:2a350133934aa7ee363fe8cd1d548b979951f162cb75789438f4e718b569b7e7  0.0s
 => => naming to docker.io/library/cfnodejsapp
 ```