### PR TITLE
fix: fail when path is not a directory for peercontainer upload/download

### DIFF
--- a/environment/peercontainer.go
+++ b/environment/peercontainer.go
@@ -169,6 +169,13 @@ func (e *PeerContainer) Destroy() error {
 
 // Download downloads the path to outside the environment
 func (e *PeerContainer) Download(path string) (string, error) {
+	fileInfo, err := e.Stat(path)
+	if err != nil {
+		return path, fmt.Errorf("failed to stat the given path : %s. Error: %v", path, err)
+	}
+	if !fileInfo.IsDir() {
+		return path, fmt.Errorf("download only supports directory paths. The path provided is %s. Error: %v", path, err)
+	}
 	output, err := os.MkdirTemp(e.TempPath, "*")
 	if err != nil {
 		return path, fmt.Errorf("failed to create temp dir. Error: %w", err)
@@ -186,6 +193,13 @@ func (e *PeerContainer) Download(path string) (string, error) {
 // Upload uploads the path from outside the environment into it
 func (e *PeerContainer) Upload(outpath string) (string, error) {
 	envpath := "/var/tmp/" + uniuri.NewLen(5) + "/" + filepath.Base(outpath)
+	fileInfo, err := os.Stat(outpath)
+	if err != nil {
+		return envpath, fmt.Errorf("failed to stat the given path : %s. Error: %v", outpath, err)
+	}
+	if !fileInfo.IsDir() {
+		return envpath, fmt.Errorf("upload only supports directory paths. The path provided is %s. Error: %v", outpath, err)
+	}
 	cengine, err := container.GetContainerEngine(false)
 	if err != nil {
 		return envpath, fmt.Errorf("failed to get the container engine. Error: %w", err)


### PR DESCRIPTION
Signed-off-by: Mehant Kammakomati <mehant.kammakomati2@ibm.com>
