### PR TITLE
feat: add workspaces to Tekton pipeline for git repo creds and registry creds

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -145,6 +145,16 @@ const (
 	ConfigTargetClusterTypeKey = ConfigTargetKey + d + "clustertype"
 	//ConfigImageRegistryKey represents image registry Key
 	ConfigImageRegistryKey = ConfigTargetKey + d + "imageregistry"
+	// ConfigCICDKey is for CICD related questions
+	ConfigCICDKey = ConfigTargetKey + d + "cicd"
+	// ConfigCICDTektonKey is for CICD Tekton pipelines
+	ConfigCICDTektonKey = ConfigCICDKey + d + "tekton"
+	// ConfigCICDTektonGitRepoSSHSecretNameKey is for Tekton git-clone ssh
+	ConfigCICDTektonGitRepoSSHSecretNameKey = ConfigCICDTektonKey + d + "gitreposshsecret"
+	// ConfigCICDTektonGitRepoBasicAuthSecretNameKey is for Tekton git-clone basic auth
+	ConfigCICDTektonGitRepoBasicAuthSecretNameKey = ConfigCICDTektonKey + d + "gitrepobasicauthsecret"
+	// ConfigCICDTektonRegistryPushSecretNameKey is for Tekton push image to registry credentials
+	ConfigCICDTektonRegistryPushSecretNameKey = ConfigCICDTektonKey + d + "registrypushsecret"
 	//ConfigTargetExistingVersionUpdate represents key which how to update versions
 	ConfigTargetExistingVersionUpdate = ConfigTargetKey + d + "existingversionupdate"
 	//ConfigImageRegistryURLKey represents image registry url Key

--- a/common/utils.go
+++ b/common/utils.go
@@ -1266,7 +1266,7 @@ func GatherGitInfo(path string) (repoName, repoDir, repoHostName, repoURL, repoB
 	if err != nil {
 		return "", "", "", "", "", fmt.Errorf("failed to parse the remote host url '%s' . Error: %w", u, err)
 	}
-	logrus.Errorf("parsed normal case - giturl: %#v", giturl)
+	logrus.Debugf("parsed normal case - giturl: %#v", giturl)
 	repoHostName = giturl.Host
 	repoName = filepath.Base(giturl.Path)
 	repoName = strings.TrimSuffix(repoName, filepath.Ext(repoName))

--- a/types/ir/ir.go
+++ b/types/ir/ir.go
@@ -26,18 +26,14 @@ import (
 	"github.com/konveyor/move2kube/transformer/kubernetes/k8sschema"
 	transformertypes "github.com/konveyor/move2kube/types/transformer"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	core "k8s.io/kubernetes/pkg/apis/core"
 	networking "k8s.io/kubernetes/pkg/apis/networking"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
-// IRArtifactType represents artifact type of IR
-const IRArtifactType transformertypes.ArtifactType = "IR"
-
-// IRConfigType represents config type of IR
-const IRConfigType transformertypes.ConfigType = "IR"
+// ContainerBuildTypeValue stores the container build type
+type ContainerBuildTypeValue string
 
 const (
 	// DockerfileContainerBuildType represents dockerfile container build type
@@ -48,10 +44,23 @@ const (
 	CNBContainerBuildTypeValue ContainerBuildTypeValue = "CNB"
 )
 
+// ContainerBuildArtifactTypeValue stores the container build artifact type
+type ContainerBuildArtifactTypeValue string
+
 const (
 	// DockerfileContainerBuildArtifactTypeValue represents dockerfile container build type artifact
 	DockerfileContainerBuildArtifactTypeValue ContainerBuildArtifactTypeValue = "Dockerfile"
+	// RelDockerfileContainerBuildArtifactTypeValue represents dockerfile container build type artifact
+	RelDockerfileContainerBuildArtifactTypeValue ContainerBuildArtifactTypeValue = "RelDockerfilePath"
+	// RelDockerfileContextContainerBuildArtifactTypeValue represents dockerfile container build type artifact
+	RelDockerfileContextContainerBuildArtifactTypeValue ContainerBuildArtifactTypeValue = "RelDockerfileContextPath"
 )
+
+// IRArtifactType represents artifact type of IR
+const IRArtifactType transformertypes.ArtifactType = "IR"
+
+// IRConfigType represents config type of IR
+const IRConfigType transformertypes.ConfigType = "IR"
 
 // IR is the intermediate representation filled by source transformers
 type IR struct {
@@ -114,12 +123,6 @@ type ServiceToPodPortForwarding struct {
 	ServiceRelPath string
 	ServiceType    core.ServiceType
 }
-
-// ContainerBuildTypeValue stores the container build type
-type ContainerBuildTypeValue string
-
-// ContainerBuildArtifactTypeValue stores the container build artifact type
-type ContainerBuildArtifactTypeValue string
 
 // ContainerImage defines images that need to be built or reused.
 type ContainerImage struct {


### PR DESCRIPTION
Also put relative paths in the Tekton pipeline when there is no git repo. This makes the pipeline more usable.

Example:
```yaml
    - name: build-push-1
      params:
        - name: IMAGE
          value: $(params.image-registry-url)/golang
        - name: DOCKERFILE
          value: '<TODO: fill this prefix starting from the root of the git repo>/golang/Dockerfile'
        - name: CONTEXT
          value: '<TODO: fill this prefix starting from the root of the git repo>/golang'
```