### PR TITLE
fix: java-war sample not producing any useful output

### DIFF
--- a/transformer/transformer.go
+++ b/transformer/transformer.go
@@ -796,11 +796,11 @@ func getArtifactsToProcess(
 			}
 		}
 		if !selected {
-			logrus.Debug("transformer was not selected")
+			logrus.Debugf("the transformer labels %#v was not selected by the 'ProcessWith' field of the artifact: %#v", tConfig.Labels, newArtifact.ProcessWith)
 			artifactsToNotProcess = append(artifactsToNotProcess, newArtifact)
 			continue
 		}
-		logrus.Debug("transformer was selected")
+		logrus.Debug("the transformer matches the 'ProcessWith' field of the artifact")
 		if processSpec.Merge {
 			artifactsToProcess = mergeArtifacts(append(artifactsToProcess, updatedArtifacts(allArtifacts, newArtifact)...))
 		} else {


### PR DESCRIPTION
The java-war artifact after being routed by a WarRouter had contradicting label selectors which meant it didn't match any of the transformers (JBoss, Liberty, Tomcat) that was supposed to handle it.