### PR TITLE
fix: Resolve move2kube images collect error

### DIFF
--- a/collector/imagescollector.go
+++ b/collector/imagescollector.go
@@ -74,7 +74,9 @@ func (c *ImagesCollector) Collect(inputDirectory string, outputPath string) erro
 			}
 			imagefile := filepath.Join(outputPath, common.NormalizeForFilename(shortesttag)+".yaml")
 			err := common.WriteYaml(imagefile, imageInfo)
-			logrus.Errorf("Unable to write file %s : %s", imagefile, err)
+			if err != nil {
+				logrus.Errorf("Unable to write file %s : %s", imagefile, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Resolves https://github.com/konveyor/move2kube/issues/1052

There was no if condition to check whether the `err` is nil or not. So, `move2kube collect -a dockercompose` would always return the error message even if the `err` is nil.

Signed-off-by: Akash Nayak <akash19nayak@gmail.com>