### PR TITLE
fix: Resolve no clean images detected issue; Remove extra blank image name

### DIFF
--- a/collector/imagescollector.go
+++ b/collector/imagescollector.go
@@ -143,8 +143,11 @@ func getAllImageNames() ([]string, error) {
 		logrus.Warnf("Error while running docker image list : %s", err)
 		return nil, err
 	}
-	images := strings.Split(strings.TrimSpace(string(outputStr)), "\n")
+	if len(outputStr) == 0 {
+		return []string{}, err
+	}
 	cleanimages := []string{}
+	images := strings.Split(strings.TrimSpace(string(outputStr)), "\n")
 	for _, image := range images {
 		if strings.HasPrefix(image, "<none>") || strings.HasSuffix(image, "<none>") {
 			logrus.Debugf("Ignore image with <none> : %s", image)

--- a/collector/imagescollector.go
+++ b/collector/imagescollector.go
@@ -143,14 +143,17 @@ func getAllImageNames() ([]string, error) {
 		logrus.Warnf("Error while running docker image list : %s", err)
 		return nil, err
 	}
-	images := strings.Split(string(outputStr), "\n")
+	images := strings.Split(strings.TrimSpace(string(outputStr)), "\n")
 	cleanimages := []string{}
 	for _, image := range images {
 		if strings.HasPrefix(image, "<none>") || strings.HasSuffix(image, "<none>") {
 			logrus.Debugf("Ignore image with <none> : %s", image)
 			continue
+		} else {
+			cleanimages = append(cleanimages, image)
 		}
 	}
+	logrus.Debugf("clean images : %s", cleanimages)
 	return cleanimages, err
 }
 


### PR DESCRIPTION
Fixes- https://github.com/konveyor/move2kube/issues/1054

```console
$ move2kube collect -a dockerswarm --log-level debug

INFO[0000] Begin collection                             
INFO[0000] [*collector.ImagesCollector] Begin collection 
DEBU[0000] images : [quay.io/konveyor/move2kube-ui:latest nginx:stable-alpine ] 
DEBU[0000] UserID not available in image metadata for [quay.io/konveyor/move2kube-ui:latest] 
DEBU[0000] UserID not available in image metadata for [nginx:stable-alpine]       
WARN[0000] Image [] not available in local image repo. Run "docker pull " 
INFO[0000] [*collector.ImagesCollector] Done            
INFO[0000] Collection done                              
INFO[0000] Collect Output in [/Users/akash/github/move2kube-demos/m2k_collect]. Copy this directory into the source directory to be used for planning.
```

There was a image with blank name getting appended to the images list because of `\n` character at the end of `outputStr` - [quay.io/konveyor/move2kube-ui:latest nginx:stable-alpine ].

Signed-off-by: Akash Nayak <akash19nayak@gmail.com>