### PR TITLE
docs: Update the documentation link in Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ More detailed instructions can be found in the [Move2Kube UI repo](https://githu
 
 `move2kube transform -s src`, where `src` is the folder containing the source artifacts.
 
-Checkout the [Tutorials](https://move2kube.konveyor.io/tutorials) and [Documentation](https://move2kube.konveyor.io/documentation) for more information.
+Checkout the [Tutorials](https://move2kube.konveyor.io/tutorials) and [Documentation](https://move2kube.konveyor.io/commands) for more information.
 
 ## Development environment setup
 


### PR DESCRIPTION
I have updated the documentation link to point to the [home page ](https://move2kube.konveyor.io/). 

Fixes #1064 