### PR TITLE
test: add a flag to generate the CPU profile for the transform command

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -25,6 +25,8 @@ const (
 	nameFlag = "name"
 	// planFlag is the name of the flag that contains the path to the plan file
 	planFlag = "plan"
+	// profileFlag is the name of the flag that contains the path where the CPU profile file should be generated
+	profileFlag = "profile"
 	// ignoreEnvFlag is the name of the flag that tells us whether to use data collected from the local machine
 	ignoreEnvFlag = "ignore-env"
 	// qaSkipFlag is the name of the flag that lets you skip all the question answers


### PR DESCRIPTION
```
$ move2kube version -l
version: v0.3.0+unreleased
gitCommit: 3a847c3366c4d2cd70167fb98f79477d683094d8
gitTreeState: clean
goVersion: go1.21.0
platform: darwin/arm64
$ move2kube transform -s src/ --qa-skip --profile mycpuprofile.pprof
$ go tool pprof /Users/haribala/go/bin/move2kube mycpuprofile.pprof
```

![profile001](https://github.com/konveyor/move2kube/assets/20921177/8ef556e6-f2a4-475f-bfd0-2f9d1b340c4f)

<img width="1007" alt="image" src="https://github.com/konveyor/move2kube/assets/20921177/029812c5-774e-4b22-b290-9cbb50295e61">

![image](https://github.com/konveyor/move2kube/assets/20921177/6d9bc9e0-ad80-43c1-aad5-d9a946143741)
