### PR TITLE
fix: add default value for loadSSHKeysOfCurrentUser qa problem

### DIFF
--- a/common/sshkeys/sshkeys.go
+++ b/common/sshkeys/sshkeys.go
@@ -114,7 +114,7 @@ func loadSSHKeysOfCurrentUser() {
 	message := `The CI/CD pipeline needs access to the git repos in order to clone, build and push.
 If any of the repos require ssh keys you will need to provide them.
 Select an option:`
-	selectedOption := qaengine.FetchSelectAnswer(common.ConfigRepoLoadPrivKey, message, nil, "", options, nil)
+	selectedOption := qaengine.FetchSelectAnswer(common.ConfigRepoLoadPrivKey, message, nil, options[2], options, nil)
 	switch selectedOption {
 	case options[0]:
 		selectedKeyFilenames, err := loadKeysFromDirectory(privateKeyDir)


### PR DESCRIPTION
When using the `qa-skip` flags, the method `loadSSHKeysOfCurrentUser` was not setting a default value:
```go
selectedOption := qaengine.FetchSelectAnswer(common.ConfigRepoLoadPrivKey, message, nil, "", options, nil)
```
This is causing a fatal error:
```
\"Unable to fetch answer. Error: 
"the QA problem object is invalid: {ID:move2kube.repo.keys.load Type:Select Desc:The CI/CD pipeline needs access to the git repos in order to clone, build and push.

If any of the repos require ssh keys you will need to provide them.

Select an option: Hints:[] Options:[Load the private SSH keys from the directory '%!s(MISSING)'/root/.ssh Provide your own key No, I will add them later if necessary.] Default: Answer:<nil> Validator:<nil> Categories:[]} . Error: the default [] is not present in the options for the QA select problem: {ID:move2kube.repo.keys.load Type:Select Desc:The CI/CD pipeline needs access to the git repos in order to clone, build and push.

If any of the repos require ssh keys you will need to provide them.

Select an option: Hints:[] Options:[Load the private SSH keys from the directory '%!s(MISSING)'/root/.ssh Provide your own key No, I will add them later if necessary.] Default: Answer:<nil> Validator:<nil> Categories:[]}
"\""
```

The simple fix is to set the default value when calling the method with the default option in the switch:
```go
selectedOption := qaengine.FetchSelectAnswer(common.ConfigRepoLoadPrivKey, message, nil, options[2], options, nil)
```
