### PR TITLE
fix: limit the size of the git clone

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -52,6 +52,7 @@ const (
 	qadisablecliFlag         = "qa-disable-cli"
 	qaportFlag               = "qa-port"
 	planProgressPortFlag     = "plan-progress-port"
+	maxCloneSizeBytesFlag    = "max-clone-size"
 	transformerSelectorFlag  = "transformer-selector"
 	qaEnabledCategoriesFlag  = "qa-enable"
 	qaDisabledCategoriesFlag = "qa-disable"

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -36,6 +36,7 @@ import (
 )
 
 type planFlags struct {
+	maxVCSRepoCloneSize   int64
 	progressServerPort    int
 	planfile              string
 	srcpath               string
@@ -64,6 +65,8 @@ func planHandler(cmd *cobra.Command, flags planFlags) {
 		common.Interrupt()
 	}()
 	defer lib.Destroy()
+
+	vcs.SetMaxRepoCloneSize(flags.maxVCSRepoCloneSize)
 
 	var err error
 	planfile := flags.planfile
@@ -182,6 +185,7 @@ func GetPlanCommand() *cobra.Command {
 	planCmd.Flags().StringSliceVar(&flags.preSets, preSetFlag, []string{}, "Specify preset config to use.")
 	planCmd.Flags().StringArrayVar(&flags.setconfigs, setConfigFlag, []string{}, "Specify config key-value pairs.")
 	planCmd.Flags().IntVar(&flags.progressServerPort, planProgressPortFlag, 0, "Port for the plan progress server. If not provided, the server won't be started.")
+	planCmd.Flags().Int64Var(&flags.maxVCSRepoCloneSize, maxCloneSizeBytesFlag, -1, "Max size in bytes when cloning a git repo. Default -1 is infinite")
 	planCmd.Flags().BoolVar(&flags.disableLocalExecution, common.DisableLocalExecutionFlag, false, "Allow files to be executed locally.")
 	planCmd.Flags().BoolVar(&flags.failOnEmptyPlan, common.FailOnEmptyPlan, false, "If true, planning will exit with a failure exit code if no services are detected (and no default transformers are found).")
 

--- a/common/vcs/git_test.go
+++ b/common/vcs/git_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/konveyor/move2kube/common"
 )
 
 func TestIsGitCommitHash(t *testing.T) {
@@ -125,45 +124,47 @@ func TestIsGitVCS(t *testing.T) {
 }
 
 func TestClone(t *testing.T) {
-	// Test case - clone a valid vcs url with overwrite true
+	t.Log("Test case - clone a valid vcs url with overwrite true")
 	gitURL := "git+https://github.com/konveyor/move2kube.git"
 	repo, err := getGitRepoStruct(gitURL)
 	if err != nil {
-		t.Errorf("failed to get git repo struct for the given git URL %s. Error : %+v", gitURL, err)
+		t.Fatalf("failed to get git repo struct for the given git URL %s. Error : %+v", gitURL, err)
 	}
 	overwrite := true
-	tempPath, err := filepath.Abs(common.RemoteTempPath)
-	if err != nil {
-		t.Errorf("failed to get absolute path of %s. Error : %+v", common.RemoteTempPath, err)
+	tempPath := t.TempDir()
+	cloneDestPath := filepath.Join(tempPath, "test-clone")
+	var infiniteSize int64 = -1
+	cloneOpts := VCSCloneOptions{
+		CommitDepth:          1,
+		Overwrite:            overwrite,
+		CloneDestinationPath: cloneDestPath,
+		MaxSize:              infiniteSize,
 	}
-	folderName := "test-clone"
-	cloneOpts := VCSCloneOptions{CommitDepth: 1, Overwrite: overwrite, CloneDestinationPath: filepath.Join(tempPath, folderName)}
 	clonedPath, err := repo.Clone(cloneOpts)
 	if err != nil {
-		t.Errorf("failed to clone the git repo. Error : %+v", err)
+		t.Fatalf("failed to clone the git repo. Error : %+v", err)
 	}
 
-	// Test case 2 - Repository already exists with overwrite true
+	t.Log("Test case 2 - Repository already exists with overwrite false")
 	gitURL = "git+https://github.com/konveyor/move2kube.git"
 	repo, err = getGitRepoStruct(gitURL)
 	if err != nil {
-		t.Errorf("failed to get git repo struct for the given git URL %s. Error : %+v", gitURL, err)
+		t.Fatalf("failed to get git repo struct for the given git URL '%s' . Error : %+v", gitURL, err)
 	}
 	overwrite = false
-	tempPath, err = filepath.Abs(common.RemoteTempPath)
-	if err != nil {
-		t.Errorf("failed to get absolute path of %s. Error : %+v", common.RemoteTempPath, err)
+	cloneOpts = VCSCloneOptions{
+		CommitDepth:          1,
+		Overwrite:            overwrite,
+		CloneDestinationPath: cloneDestPath,
+		MaxSize:              infiniteSize,
 	}
-	folderName = "test-clone"
-	cloneOpts = VCSCloneOptions{CommitDepth: 1, Overwrite: overwrite, CloneDestinationPath: filepath.Join(tempPath, folderName)}
 	clonedPathWithoutOverwrite, err := repo.Clone(cloneOpts)
 	if err != nil {
-		t.Errorf("failed to clone the git repo. Error : %+v", err)
+		t.Fatalf("failed to clone the git repo. Error : %+v", err)
 	}
 	if clonedPath != clonedPathWithoutOverwrite {
-		t.Errorf("cloned paths did not match with overwrite false. cloned path %s, cloned path without overwrite: %s", clonedPath, clonedPathWithoutOverwrite)
+		t.Fatalf("cloned paths did not match with overwrite false. cloned path '%s', cloned path without overwrite: '%s'", clonedPath, clonedPathWithoutOverwrite)
 	}
-
 }
 
 func TestIsGitBranch(t *testing.T) {

--- a/common/vcs/limit.go
+++ b/common/vcs/limit.go
@@ -1,0 +1,51 @@
+package vcs
+
+import (
+	"errors"
+	"sync/atomic"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage"
+)
+
+var ErrLimitExceeded = errors.New("repo size limit exceeded")
+
+// Limited wraps git.Storer to limit the number of bytes that can be stored.
+type Limited struct {
+	storage.Storer
+	N atomic.Int64
+}
+
+// Limit returns a git.Storer limited to the specified number of bytes.
+func Limit(s storage.Storer, n int64) storage.Storer {
+	if n < 0 {
+		return s
+	}
+	l := &Limited{Storer: s}
+	l.N.Store(n)
+	return l
+}
+
+func (s *Limited) SetEncodedObject(obj plumbing.EncodedObject) (plumbing.Hash, error) {
+	objSize := obj.Size()
+	n := s.N.Load()
+	if n-objSize < 0 {
+		return plumbing.ZeroHash, ErrLimitExceeded
+	}
+	for !s.N.CompareAndSwap(n, n-objSize) {
+		n = s.N.Load()
+		if n-objSize < 0 {
+			return plumbing.ZeroHash, ErrLimitExceeded
+		}
+	}
+	return s.Storer.SetEncodedObject(obj)
+}
+
+func (s *Limited) Module(name string) (storage.Storer, error) {
+	m, err := s.Storer.Module(name)
+	if err != nil {
+		return nil, err
+	}
+	n := s.N.Load()
+	return Limit(m, n), nil
+}

--- a/common/vcs/limit.go
+++ b/common/vcs/limit.go
@@ -1,3 +1,19 @@
+/*
+ *  Copyright IBM Corporation 2023
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package vcs
 
 import (
@@ -8,6 +24,7 @@ import (
 	"github.com/go-git/go-git/v5/storage"
 )
 
+// ErrLimitExceeded is the error returned when the storage limit has been exceeded (usually during git clone)
 var ErrLimitExceeded = errors.New("repo size limit exceeded")
 
 // Limited wraps git.Storer to limit the number of bytes that can be stored.
@@ -26,6 +43,7 @@ func Limit(s storage.Storer, n int64) storage.Storer {
 	return l
 }
 
+// SetEncodedObject is a Storer interface method that is used to store an object
 func (s *Limited) SetEncodedObject(obj plumbing.EncodedObject) (plumbing.Hash, error) {
 	objSize := obj.Size()
 	n := s.N.Load()
@@ -41,6 +59,7 @@ func (s *Limited) SetEncodedObject(obj plumbing.EncodedObject) (plumbing.Hash, e
 	return s.Storer.SetEncodedObject(obj)
 }
 
+// Module is a Storer interface method that is used to get the working tree for a repo sub-module
 func (s *Limited) Module(name string) (storage.Storer, error) {
 	m, err := s.Storer.Module(name)
 	if err != nil {

--- a/common/vcs/vcs.go
+++ b/common/vcs/vcs.go
@@ -54,6 +54,7 @@ var (
 	maxRepoCloneSize int64 = -1
 )
 
+// SetMaxRepoCloneSize sets the maximum size (in bytes) for cloning a repo
 func SetMaxRepoCloneSize(size int64) {
 	maxRepoCloneSize = size
 }

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -223,8 +223,8 @@ func (e *Environment) Encode(obj interface{}) interface{} {
 		}
 		return e.Env.Upload(path)
 	}
-	if reflect.ValueOf(obj).Kind() == reflect.String {
-		val, err := processPath(obj.(string))
+	if objS, ok := obj.(string); ok {
+		val, err := processPath(objS)
 		if err != nil {
 			logrus.Errorf("Unable to process paths for obj %+v : %s", obj, err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/konveyor/move2kube
 
-go 1.18
+go 1.19
 
 require (
 	code.cloudfoundry.org/cli v7.1.0+incompatible
@@ -18,12 +18,14 @@ require (
 	github.com/docker/cli v23.0.3+incompatible
 	github.com/docker/docker v23.0.3+incompatible
 	github.com/docker/libcompose v0.4.1-0.20171025083809-57bd716502dc
+	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-cmp v0.5.9
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/joho/godotenv v1.4.0
+	github.com/kopoli/go-terminal-size v0.0.0-20170219200355-5c97524c8b54
 	github.com/magiconair/properties v1.8.5
 	github.com/mikefarah/yq/v4 v4.16.2
 	github.com/mitchellh/mapstructure v1.4.3
@@ -109,7 +111,6 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
-	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-kit/log v0.2.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
@@ -149,7 +150,6 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kevinburke/ssh_config v1.1.0 // indirect
 	github.com/klauspost/compress v1.16.0 // indirect
-	github.com/kopoli/go-terminal-size v0.0.0-20170219200355-5c97524c8b54 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect

--- a/lib/planner.go
+++ b/lib/planner.go
@@ -32,10 +32,16 @@ import (
 func CreatePlan(ctx context.Context, inputPath, outputPath string, customizationsPath, transformerSelector, prjName string) (plantypes.Plan, error) {
 	logrus.Trace("CreatePlan start")
 	defer logrus.Trace("CreatePlan end")
-	remoteInputFSPath := vcs.GetClonedPath(inputPath, common.RemoteSourcesFolder, true)
-	remoteOutputFSPath := vcs.GetClonedPath(outputPath, common.RemoteOutputsFolder, true)
-	logrus.Debugf("common.TempPath: '%s' inputPath: '%s' remoteInputFSPath '%s'", common.TempPath, inputPath, remoteInputFSPath)
 	plan := plantypes.NewPlan()
+	remoteInputFSPath, err := vcs.GetClonedPath(inputPath, common.RemoteSourcesFolder, true)
+	if err != nil {
+		return plan, fmt.Errorf("failed to clone the repo '%s'. Error: %w", inputPath, err)
+	}
+	remoteOutputFSPath, err := vcs.GetClonedPath(outputPath, common.RemoteOutputsFolder, true)
+	if err != nil {
+		return plan, fmt.Errorf("failed to clone the repo '%s'. Error: %w", outputPath, err)
+	}
+	logrus.Debugf("common.TempPath: '%s' inputPath: '%s' remoteInputFSPath '%s'", common.TempPath, inputPath, remoteInputFSPath)
 	plan.Name = prjName
 	common.ProjectName = prjName
 	plan.Spec.SourceDir = inputPath

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -32,7 +32,10 @@ const TransformerTypeMeta = "Transformer"
 
 // CheckAndCopyCustomizations checks if the customizations path is an existing directory and copies to assets
 func CheckAndCopyCustomizations(customizationsPath string) error {
-	remoteCustomizationsPath := vcs.GetClonedPath(customizationsPath, common.RemoteCustomizationsFolder, true)
+	remoteCustomizationsPath, err := vcs.GetClonedPath(customizationsPath, common.RemoteCustomizationsFolder, true)
+	if err != nil {
+		return fmt.Errorf("failed to clone the repo. Error: %w", err)
+	}
 	customizationsFSPath := customizationsPath
 	if remoteCustomizationsPath != "" {
 		customizationsFSPath = remoteCustomizationsPath
@@ -40,7 +43,7 @@ func CheckAndCopyCustomizations(customizationsPath string) error {
 	if customizationsFSPath == "" {
 		return nil
 	}
-	customizationsFSPath, err := filepath.Abs(customizationsFSPath)
+	customizationsFSPath, err = filepath.Abs(customizationsFSPath)
 	if err != nil {
 		return fmt.Errorf("failed to make the customizations directory path '%s' absolute. Error: %w", customizationsFSPath, err)
 	}


### PR DESCRIPTION
Set a max repo size while cloning.
Added a `--max-clone-size` flag to both the `plan` and `transform` commands.
It is the maximum size in bytes. Default is -1 where negative values mean infinite bytes.

DOES NOT FIX the bug found in the `main` branch while making this PR https://github.com/konveyor/move2kube/issues/1110
`af4d50b1e5522c2a41c34894aa8cf433f5845bb9`
