### PR TITLE
test: add tests for mergeDeletionCallBack

### DIFF
--- a/filesystem/merger_test.go
+++ b/filesystem/merger_test.go
@@ -1,4 +1,18 @@
-
+/*
+ *  Copyright IBM Corporation 2021
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package filesystem
 
 import (

--- a/filesystem/merger_test.go
+++ b/filesystem/merger_test.go
@@ -1,0 +1,72 @@
+// package filesystem
+
+// import (
+// 	"os"
+// 	"testing"
+// )
+
+// func TestMergeDeletionCallBack(t *testing.T) {
+// 	t.Run("test for source file and destination directory", func(t *testing.T) {
+// 		source := "/move2kube/to/nonexistent/source"
+// 		destination := "/move2kube/to/destination"
+// 		config := interface{}(nil)
+
+// 		// Call the merge function
+// 		err := mergeDeletionCallBack(source, destination, config)
+
+// 		// Assert that the error is not nil (as the source file does not exist)
+// 		if err == nil {
+// 			t.Fatalf("Expected non-nil error, but got nil")
+// 		}
+
+// 		// Check if the error is due to the source file not existing
+// 		if !os.IsNotExist(err) {
+// 			t.Fatalf("Expected source file to not exist, but got error: %v", err)
+// 		}
+
+// 		// Additional checks based on the expected behavior after fixing the source path
+// 		// For example, check the state of the destination directory or other behavior
+// 		_, destErr := os.Stat(destination)
+// 		if destErr == nil {
+// 			t.Error("Expected destination directory not to exist, but it exists")
+// 		}
+
+// 		// Additional checks specific to your expected behavior can be added here
+// 	})
+// }
+package filesystem
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMergeDeletionCallBack(t *testing.T) {
+	t.Run(" test for scenario when function is called with a non-existent source file and an existing destination directory", func(t *testing.T) {
+		source := "/move2kube/nonexistent/source"
+		destination := "/move2kube/destination"
+		config := interface{}(nil)
+
+		// Call the merge function
+		err := mergeDeletionCallBack(source, destination, config)
+
+		// Assert that the error is not nil (as the source file does not exist)
+		if err == nil {
+			t.Fatalf("Expected non-nil error, but got nil")
+		}
+
+		// Check if the error is due to the source file not existing
+		if !os.IsNotExist(err) {
+			t.Fatalf("Expected source file to not exist, but got error: %v", err)
+		}
+
+		// Additional checks based on the expected behavior after fixing the source path
+		// For example, check the state of the destination directory or other behavior
+		_, destErr := os.Stat(destination)
+		if !os.IsNotExist(destErr) {
+			t.Error("Expected destination directory not to exist, but it exists")
+		}
+
+		// Additional checks specific to your expected behavior can be added here
+	})
+}

--- a/filesystem/merger_test.go
+++ b/filesystem/merger_test.go
@@ -25,13 +25,12 @@ func TestMergeDeletionCallBack(t *testing.T) {
 			t.Fatalf("Expected source file to not exist, but got error: %v", err)
 		}
 
-		// Additional checks based on the expected behavior after fixing the source path
-		// For example, check the state of the destination directory or other behavior
+		
 		_, destErr := os.Stat(destination)
 		if !os.IsNotExist(destErr) {
 			t.Error("Expected destination directory not to exist, but it exists")
 		}
 
-		// Additional checks specific to your expected behavior can be added here
+		
 	})
 }

--- a/filesystem/merger_test.go
+++ b/filesystem/merger_test.go
@@ -1,39 +1,4 @@
-// package filesystem
 
-// import (
-// 	"os"
-// 	"testing"
-// )
-
-// func TestMergeDeletionCallBack(t *testing.T) {
-// 	t.Run("test for source file and destination directory", func(t *testing.T) {
-// 		source := "/move2kube/to/nonexistent/source"
-// 		destination := "/move2kube/to/destination"
-// 		config := interface{}(nil)
-
-// 		// Call the merge function
-// 		err := mergeDeletionCallBack(source, destination, config)
-
-// 		// Assert that the error is not nil (as the source file does not exist)
-// 		if err == nil {
-// 			t.Fatalf("Expected non-nil error, but got nil")
-// 		}
-
-// 		// Check if the error is due to the source file not existing
-// 		if !os.IsNotExist(err) {
-// 			t.Fatalf("Expected source file to not exist, but got error: %v", err)
-// 		}
-
-// 		// Additional checks based on the expected behavior after fixing the source path
-// 		// For example, check the state of the destination directory or other behavior
-// 		_, destErr := os.Stat(destination)
-// 		if destErr == nil {
-// 			t.Error("Expected destination directory not to exist, but it exists")
-// 		}
-
-// 		// Additional checks specific to your expected behavior can be added here
-// 	})
-// }
 package filesystem
 
 import (


### PR DESCRIPTION
## tests for mergeDeletionCallback
i) This test case covers a scenario when function is called with a non-existent source file and an existing destination directory

fixes a part of #881 