### PR TITLE
fix: install openssh in Dockerfile in order to be able to clone repo using ssh keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,8 @@ VOLUME ["/workspace"]
 #"/var/run/docker.sock" needs to be mounted for container based transformers to work with docker
 # Start app
 WORKDIR /workspace
+
+RUN microdnf install -y openssh openssh-clients
+RUN mkdir -p $HOME/.ssh
+
 CMD move2kube


### PR DESCRIPTION
When I try to use ssh key to clone the git repo:
```
move2kube plan -s git+ssh://bitbucket.org/gfarache31/m2k-test@master
```
I get the following error:
```
FATA[0000] failed to create the plan. Error: "failed to clone the repo 'git+ssh://bitbucket.org/gfarache31/m2k-test'. Error: failed to clone using vcs url 'git+ssh://bitbucket.org/gfarache31/m2k-test' and clone options {CommitDepth:1 Overwrite:true MaxSize:-1 CloneDestinationPath:/tmp/move2kube1491402545/m2ksources}. Error: failed to perform clone operation using git with options {URL:git@bitbucket.org:gfarache31/m2k-test Auth:<nil> RemoteName:origin ReferenceName:refs/heads/main SingleBranch:true Mirror:false NoCheckout:false Depth:1 RecurseSubmodules:0 Progress:<nil> Tags:2 InsecureSkipTLS:false CABundle:[] ProxyOptions:{URL: Username: Password:}} and {CommitDepth:1 Overwrite:true MaxSize:-1 CloneDestinationPath:/tmp/move2kube1491402545/m2ksources}. Error: error creating SSH agent: \"SSH agent requested but SSH_AUTH_SOCK not-specified\""
```

If in install openssh I run the following, it works:
```
eval $(ssh-agent -s)
<create pub and priv keys in .ssh>
ssh-add .ssh/id_rsa
ssh-keyscan -t rsa bitbucket.org > .ssh/known_hosts
move2kube plan -s git+ssh://bitbucket.org/gfarache31/m2k-test@master
```

So in order to fix this, I add the following in the Dockerfile:
```
RUN microdnf install -y openssh openssh-clients
RUN mkdir -p $HOME/.ssh
RUN printf "bitbucket.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIazEu89wgQZ4bqs3d63QSMzYVa0MuJ2e2gKTKqu+UUO\ngithub.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==\ngitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf\ngitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9\ngitlab.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=\nbitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==" > $HOME/.ssh/known_hosts
```

The values added in the known_hosts file are copied from `common/sshkeys/sshkeys.go`