### PR TITLE
fix: gox cross compilation was failing asking for a `go mod tidy`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/docker/cli v23.0.3+incompatible
 	github.com/docker/docker v23.0.3+incompatible
 	github.com/docker/libcompose v0.4.1-0.20171025083809-57bd716502dc
-	github.com/go-git/go-billy/v5 v5.3.1
+	github.com/go-git/go-billy/v5 v5.4.1
 	github.com/go-git/go-git/v5 v5.7.0
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-cmp v0.5.9
@@ -116,7 +116,6 @@ require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.4.1 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect


### PR DESCRIPTION
Fix the error
```shell
$ VERSION='v0.3.12-rc.0' make dist
rm -rf /Users/haribala/Documents/code/remote/github.com/konveyor/move2kube/bin /Users/haribala/Documents/code/remote/github.com/konveyor/move2kube/_dist
go clean -cache
cd / && GO111MODULE=on go install  github.com/mitchellh/gox@v1.0.1
go: downloading github.com/mitchellh/gox v1.0.1
go: downloading github.com/mitchellh/iochan v1.0.0
go: downloading github.com/hashicorp/go-version v1.0.0
CGO_ENABLED=0 /Users/haribala/go/bin/gox -parallel=3 -output="/Users/haribala/Documents/code/remote/github.com/konveyor/move2kube/_dist/{{.OS}}-{{.Arch}}/move2kube" -osarch='darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 linux/s390x linux/ppc64le windows/amd64' -ldflags '-w -s -X github.com/konveyor/move2kube/types/info.version=v0.3.12-rc.0 -X github.com/konveyor/move2kube/types/info.buildmetadata=unreleased -X github.com/konveyor/move2kube/types/info.gitCommit=3fd20336c814245331beb690de9226efd607684a -X github.com/konveyor/move2kube/types/info.gitTreeState=clean' .
error reading Go version: exit status 1
Stderr: go: updates to go.mod needed; to update it:
	go mod tidy
make: *** [build-cross] Error 1
```