### PR TITLE
fix: QA categories were being used only by the CLI engine 

### DIFF
--- a/qaengine/cliengine.go
+++ b/qaengine/cliengine.go
@@ -51,21 +51,6 @@ func (c *CliEngine) FetchAnswer(prob qatypes.Problem) (qatypes.Problem, error) {
 		logrus.Errorf("the QA problem object is invalid. Error: %q", err)
 		return prob, err
 	}
-	// return default if the category is skipped
-	probCategories := qatypes.GetProblemCategories(prob.ID, prob.Categories)
-	for _, category := range probCategories {
-		if common.IsStringPresent(common.DisabledCategories, category) {
-			// if prob.Default == nil {
-			// 	// todo: warn instead of returning error
-			// 	return prob, errors.New(fmt.Sprintf("category %s is skipped but default doesn't exist", category)) // TODO:
-			// }
-			if err := prob.SetAnswer(prob.Default, true); err != nil {
-				return prob, fmt.Errorf("failed to set the given solution as the answer. Error: %w", err)
-			}
-			return prob, nil
-		}
-	}
-
 	switch prob.Type {
 	case qatypes.SelectSolutionFormType:
 		return c.fetchSelectAnswer(prob)

--- a/qaengine/engine.go
+++ b/qaengine/engine.go
@@ -118,6 +118,19 @@ func SetupConfigFile(writeConfigFile string, configStrings, configFiles, presets
 	}
 }
 
+func isQuestionDisabled(prob qatypes.Problem) bool {
+	isDisabled := false
+	probCategories := qatypes.GetProblemCategories(prob.ID, prob.Categories)
+	for _, category := range probCategories {
+		if common.IsStringPresent(common.DisabledCategories, category) {
+			logrus.Debugf("Question belongs to the disabled category: %s", category)
+			isDisabled = true
+			break
+		}
+	}
+	return isDisabled
+}
+
 // FetchAnswer fetches the answer for the question
 func FetchAnswer(prob qatypes.Problem) (qatypes.Problem, error) {
 	logrus.Trace("FetchAnswer start")
@@ -126,6 +139,9 @@ func FetchAnswer(prob qatypes.Problem) (qatypes.Problem, error) {
 	if prob.Answer != nil {
 		logrus.Debugf("Problem already solved.")
 		return prob, nil
+	}
+	if isQuestionDisabled(prob) {
+		return defaultEngine.FetchAnswer(prob)
 	}
 	var err error
 	logrus.Debug("looping through the engines to try and fetch the answer")


### PR DESCRIPTION
Updated the QA http rest engine of Move2Kube required for adding QA category enable/disable support to Move2Kube API https://github.com/konveyor/move2kube/issues/1155, https://github.com/konveyor/move2kube/issues/1151#issuecomment-1993816895. For the disabled categories, the QA engine should automatically consider the default answer as the input answer. 

Signed-off-by: Akash Nayak <akash19nayak@gmail.com>