### PR TITLE
fix: When the m2kignore file is removed from language_platforms.zip then in the UI only the Ruby service is detected

### DIFF
--- a/transformer/dockerfilegenerator/rubydockerfiletransformer.go
+++ b/transformer/dockerfilegenerator/rubydockerfiletransformer.go
@@ -59,7 +59,7 @@ func (t *RubyDockerfileGenerator) GetConfig() (transformertypes.Transformer, *en
 
 // DirectoryDetect runs detect in each sub directory
 func (t *RubyDockerfileGenerator) DirectoryDetect(dir string) (map[string][]transformertypes.Artifact, error) {
-	gemfilePaths, err := common.GetFilesByName(dir, []string{"Gemfile"}, nil)
+	gemfilePaths, err := common.GetFilesInCurrentDirectory(dir, []string{"Gemfile"}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to look for Gemfiles in the dir %s . Error: %q", dir, err)
 	}


### PR DESCRIPTION
Fixes - https://github.com/konveyor/move2kube/issues/1159

Move2Kube-UI detects all the services in the language-platforms, whereas earlier it was only detecting the Ruby service.

<img width="1398" alt="Screenshot 2024-03-21 at 1 26 45 AM" src="https://github.com/konveyor/move2kube/assets/14867323/890cfad9-41c0-4875-9bac-cead839acc9c">

```yaml
apiVersion: move2kube.konveyor.io/v1alpha1
kind: Plan
metadata:
  name: test
spec:
  sourceDir: sources
  services:
    django:
      - transformerName: Python-Dockerfile
        paths:
          MainPythonFilesPathType:
            - language-platforms/language-platforms/django/manage.py
          PythonFilesPathType:
            - language-platforms/language-platforms/django/manage.py
          RequirementsTxtPathType:
            - language-platforms/language-platforms/django/requirements.txt
          ServiceDirectories:
            - language-platforms/language-platforms/django
        configs:
          OriginalName:
            originalName: django
          PythonConfig:
            IsDjango: true
    golang:
      - transformerName: Golang-Dockerfile
        paths:
          GoModFilePath:
            - language-platforms/language-platforms/golang/go.mod
          ServiceDirectories:
            - language-platforms/language-platforms/golang
        configs:
          OriginalName:
            originalName: golang
    java-gradle:
      - transformerName: Gradle
        paths:
          GradleBuildFile:
            - language-platforms/language-platforms/java-gradle/build.gradle
          GradleSettingsFile:
            - language-platforms/language-platforms/java-gradle/settings.gradle
          ServiceDirectories:
            - language-platforms/language-platforms/java-gradle
          ServiceRootDirectory:
            - language-platforms/language-platforms/java-gradle
        configs:
          Gradle:
            rootProjectName: java-gradle
            packagingType: war
            isGradlewPresent: true
            childModules:
              - name: java-gradle
                buildScriptPath: build.gradle
    java-maven:
      - transformerName: Maven
        paths:
          ServiceDirectories:
            - language-platforms/language-platforms/java-maven
          ServiceRootDirectory:
            - language-platforms/language-platforms/java-maven
          pomFiles:
            - language-platforms/language-platforms/java-maven/pom.xml
        configs:
          Maven:
            mavenAppName: java-maven
            packagingType: war
            isMvnwPresent: false
            childModules:
              - name: java-maven
                pomPath: pom.xml
    java-war:
      - transformerName: WarAnalyser
        paths:
          ServiceDirectories:
            - language-platforms/language-platforms/java-war
          War:
            - language-platforms/language-platforms/java-war/java-war.war
        configs:
          ImageName:
            imageName: java-war
          War:
            port: 0
            javaVersion: "17"
            buildContainerName: ""
            deploymentFilePath: java-war.war
            envVariables: {}
    nodejs:
      - transformerName: Nodejs-Dockerfile
        paths:
          ServiceDirectories:
            - language-platforms/language-platforms/nodejs
        configs:
          OriginalName:
            originalName: nodejs
    php:
      - transformerName: PHP-Dockerfile
        paths:
          ServiceDirectories:
            - language-platforms/language-platforms/php
        configs:
          OriginalName:
            originalName: php
    python:
      - transformerName: Python-Dockerfile
        paths:
          MainPythonFilesPathType:
            - language-platforms/language-platforms/python/main.py
          PythonFilesPathType:
            - language-platforms/language-platforms/python/main.py
          RequirementsTxtPathType:
            - language-platforms/language-platforms/python/requirements.txt
          ServiceDirectories:
            - language-platforms/language-platforms/python
        configs:
          OriginalName:
            originalName: python
          PythonConfig:
            IsDjango: false
    ruby:
      - transformerName: Ruby-Dockerfile
        paths:
          ServiceDirectories:
            - language-platforms/language-platforms/ruby
        configs:
          OriginalName:
            originalName: ruby
    rust:
      - transformerName: Rust-Dockerfile
        paths:
          ServiceDirectories:
            - language-platforms/language-platforms/rust
        configs:
          OriginalName:
            originalName: rust
```
