### PR TITLE
fix: K8s version change transformer was not being run sometimes because Parameterizer was running first

### DIFF
--- a/assets/built-in/transformers/kubernetes/kubernetesversionchanger/transformer.yaml
+++ b/assets/built-in/transformers/kubernetes/kubernetesversionchanger/transformer.yaml
@@ -4,6 +4,7 @@ metadata:
   name: KubernetesVersionChanger
   labels:
     move2kube.konveyor.io/built-in: true
+    move2kube.konveyor.io/sort-order: 9999
 spec:
   class: "KubernetesVersionChanger"
   directoryDetect:

--- a/assets/built-in/transformers/kubernetes/parameterizer/transformer.yaml
+++ b/assets/built-in/transformers/kubernetes/parameterizer/transformer.yaml
@@ -4,6 +4,7 @@ metadata:
   name: Parameterizer
   labels:
     move2kube.konveyor.io/built-in: true
+    move2kube.konveyor.io/sort-order: 10000
 spec:
   class: "Parameterizer"
   directoryDetect:

--- a/common/utils.go
+++ b/common/utils.go
@@ -59,6 +59,34 @@ import (
 	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
+// sorting
+
+// Sortable is an implementation of the sort.Interface interface.
+// This is useful when you want to sort one slice using another slice.
+type Sortable[T any] struct {
+	Xs []T
+	Ys []int
+}
+
+// Len is the number of elements in the collection.
+func (s *Sortable[T]) Len() int {
+	return len(s.Xs)
+}
+
+// Less reports whether the element with index i
+// must sort before the element with index j.
+func (s *Sortable[T]) Less(i, j int) bool {
+	return s.Ys[i] < s.Ys[j]
+}
+
+// Swap swaps the elements with indexes i and j.
+func (s *Sortable[T]) Swap(i, j int) {
+	s.Xs[i], s.Xs[j] = s.Xs[j], s.Xs[i]
+	s.Ys[i], s.Ys[j] = s.Ys[j], s.Ys[i]
+}
+
+// sorting
+
 // LookupEnv looks for a environment variable in a list of environment variables
 func LookupEnv(envNameToLookup string, envList []core.EnvVar) (core.EnvVar, bool) {
 	for _, env := range envList {


### PR DESCRIPTION
feat: Added a new feature to sort transformers based on a label `move2kube.konveyor.io/sort-order` specified in the `transformer.yaml`. This is only the initial sorted order in which transformers are run and does not affect dependency related stuff like `MandatoryPassThrough`.