### PR TITLE
feat: add a flag to profile the heap memory

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -27,6 +27,10 @@ const (
 	planFlag = "plan"
 	// profileFlag is the name of the flag that contains the path where the CPU profile file should be generated
 	profileFlag = "profile"
+	// profileTypeFlag is the name of the flag that contains the type of profiling that should be performed
+	profileTypeFlag = "profile-type"
+	// profileIntervalFlag is the name of the flag that contains the frequency with which we profile the heap memory
+	profileIntervalFlag = "profile-interval-ms"
 	// ignoreEnvFlag is the name of the flag that tells us whether to use data collected from the local machine
 	ignoreEnvFlag = "ignore-env"
 	// qaSkipFlag is the name of the flag that lets you skip all the question answers


### PR DESCRIPTION
```
$ move2kube help transform
Transform artifacts using move2kube plan

Usage:
  move2kube transform [flags]

Flags:
...................
      --profile string                Path where the CPU profile file should be generated. By default we don't profile.
      --profile-interval-ms int       Time (in milliseconds) between samples of the heap memory profile. Default 500ms. This flag is only used if the --profile-type flag is set to 'heap'. (default 500)
      --profile-type string           The type of profiling that should be performed. Valid values are 'cpu' and 'heap' (Default 'cpu'). This flag is only used if the --profile flag is also provided. (default "cpu")
...................


$ move2kube transform -s language-platforms/ --profile m2kmem --profile-type heap --profile-interval-ms 250 --qa-skip
INFO[0000] Starting Heap Memory profiling (profile every 250 milliseconds) 
INFO[0000] No plan file found.                          
INFO[0000] Using the default QA mappings file           
INFO[0000] Configuration loading done                   
INFO[0000] Start planning                               
INFO[0000] Planning started on the base directory: '/Users/haribala/Desktop/runs/inputs/temp/language-platforms' 
INFO[0000] [ComposeAnalyser] Planning                   
INFO[0000] [ComposeAnalyser] Done                       
INFO[0000] [DockerfileDetector] Planning                
INFO[0000] [DockerfileDetector] Done                    
$ ls
language-platforms	m2k-graph.json		m2kconfig.yaml		m2kmem			m2kqacache.yaml		myproject
$ ls m2kmem/
mem-1	mem-10	mem-2	mem-3	mem-4	mem-5	mem-6	mem-7	mem-8	mem-9
$ go tool pprof -svg -output m2kmem/mem-10.svg m2kmem/mem-10
Generating report in m2kmem/mem-10.svg
```

<img width="796" alt="image" src="https://github.com/konveyor/move2kube/assets/20921177/26687b20-5997-4ccc-807e-15c261ae55d6">
