### PR TITLE
ci: use the fixed version of artifact upload action to avoid http 404 error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
           go-version: ${{ steps.info.outputs.go_version }}
       - run: VERSION='${{ github.event.inputs.tag }}' make dist
       - name: upload release assets
-        uses: konveyor/move2kube-upload-release-action@v3
+        uses: konveyor/move2kube-upload-release-action@v3.0.1
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
See https://github.com/konveyor/move2kube/actions/runs/10047005376/job/27769138341#step:8:44