### PR TITLE
fix: bug where plan phase was not using the customizations folder

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -89,7 +89,7 @@ Exiting.`, outpath, overwriteFlag, outputFlag)
 func getCustomMappingFilePath() (qaenginetypes.QAMappings, error) {
 	// Read the QA categories from the QA mapping file
 	var qaMapping qaenginetypes.QAMappings
-	customizationsDir := filepath.Join(common.AssetsPath, "custom")
+	customizationsDir := filepath.Join(common.AssetsPath, common.AssetsCustomizationsDir)
 	_, err := os.Stat(customizationsDir)
 	if err == nil {
 		yamlPaths, err := common.GetFilesByExt(customizationsDir, []string{".yml", ".yaml"})
@@ -113,7 +113,7 @@ func getCustomMappingFilePath() (qaenginetypes.QAMappings, error) {
 		}
 	}
 	logrus.Infof("Using the default QA mappings file")
-	qaMappingFilepath := filepath.Join("built-in/qa", "qamappings.yaml")
+	qaMappingFilepath := filepath.Join("built-in", "qa", "qamappings.yaml")
 	file, err := assets.AssetsDir.ReadFile(qaMappingFilepath)
 	if err != nil {
 		return qaMapping, fmt.Errorf("failed to read the mappings file metadata from the yaml file at path '%s' . Error: %w", qaMappingFilepath, err)

--- a/common/constants.go
+++ b/common/constants.go
@@ -60,6 +60,9 @@ const (
 	ShExt = ".sh"
 	// BatExt is the extension of bat file
 	BatExt = ".bat"
+	// AssetsCustomizationsDir is a directory inside the assets directory
+	// where the user given customizations are copied to.
+	AssetsCustomizationsDir = "custom"
 	// RemoteSourcesFolder stores remote sources
 	RemoteSourcesFolder = "m2ksources"
 	// RemoteCustomizationsFolder stores remote customizations

--- a/lib/planner.go
+++ b/lib/planner.go
@@ -54,6 +54,11 @@ func CreatePlan(ctx context.Context, inputPath, outputPath string, customization
 	if remoteOutputFSPath != "" {
 		outputFSPath = remoteOutputFSPath
 	}
+	if customizationsPath != "" {
+		if err := CheckAndCopyCustomizations(customizationsPath); err != nil {
+			return plan, fmt.Errorf("failed to check and copy the customizations. Error: %w", err)
+		}
+	}
 	transformerSelectorObj, err := metav1.ParseToLabelSelector(transformerSelector)
 	if err != nil {
 		return plan, fmt.Errorf("failed to parse the string '%s' as a transformer selector. Error: %w", transformerSelector, err)

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -84,7 +84,7 @@ func CopyCustomizationsAssetsData(customizationsPath string) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to make the assets path '%s' absolute. Error: %w", assetsPath, err)
 	}
-	customizationsAssetsPath := filepath.Join(assetsPath, "custom")
+	customizationsAssetsPath := filepath.Join(assetsPath, common.AssetsCustomizationsDir)
 
 	// Create the subdirectory and copy the assets into it.
 	if err = os.MkdirAll(customizationsAssetsPath, common.DefaultDirectoryPermission); err != nil {


### PR DESCRIPTION
fix: bug where forward slash "/" was hardcoded in the path of the default qamappings file, causing file not exist error and a crash on Windows (Windows uses back slash)